### PR TITLE
[preload] Match declartion of tmpnam with glibc

### DIFF
--- a/preload/chrootgate.c
+++ b/preload/chrootgate.c
@@ -44,21 +44,19 @@ int chroot_gate(int *result_errno_ptr,
 
 	/* Parameter 'path' may not be a clean path,
 	 * and it isn't necessarily even absolute path. */
-	if (*path == '/') {
+	if (*path == '/' && sbox_chroot_path) {
 		char	*path2 = NULL;
 		/* "path" is absolute == really it is relative to
 		 * sbox_chroot_path if that is set; otherwise it is
 		 * relative to the virtual root */
-		if (sbox_chroot_path) {
-			if (asprintf(&path2, "%s/%s", sbox_chroot_path, path) < 0) {
-				*result_errno_ptr = EIO;
-				return(-1);
-			}
-			SB_LOG(SB_LOGLEVEL_DEBUG, "chroot, old dir='%s'",
-				sbox_chroot_path);
-		} else {
-			path2 = path;
+
+		if (asprintf(&path2, "%s/%s", sbox_chroot_path, path) < 0) {
+			*result_errno_ptr = EIO;
+			return(-1);
 		}
+		SB_LOG(SB_LOGLEVEL_DEBUG, "chroot, old dir='%s'",
+		       sbox_chroot_path);
+
 		/* sbox_virtual_path_to_abs_virtual_path() will clean it */
 		new_chroot_path = sbox_virtual_path_to_abs_virtual_path(
 			sbox_binary_name, realfnname, SB2_INTERFACE_CLASS_CHROOT,

--- a/preload/chrootgate.c
+++ b/preload/chrootgate.c
@@ -24,7 +24,9 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+
 #include "sb2.h"
+#include "sb2_stat.h"
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/interface.master
+++ b/preload/interface.master
@@ -786,7 +786,7 @@ WRAP: int mkostemps64(char *template, int suffixlen, int flags) : \
 -- that did not exist when the function was called. These need to do path
 -- mapping when performing the tests.. because of that we need to replace
 -- these functions completely.
-GATE: char *tmpnam(char *s) : returns_string
+GATE: char *tmpnam(char __s[L_tmpnam]) : returns_string
 GATE: char *tempnam(const char *tmpdir, const char *prefix) : returns_string
 WRAP: char *mktemp(char *template) : \
 	map(template) \

--- a/preload/tmpnamegates.c
+++ b/preload/tmpnamegates.c
@@ -180,8 +180,8 @@ extern void mkostemps64_postprocess_template(const char *realfnname,
 */
 char *tmpnam_gate(
 	int *result_errno_ptr,
-	char *(*real_tmpnam_ptr)(char *s),
-	const char *realfnname, char *s)
+	char *(*real_tmpnam_ptr)(char __s[L_tmpnam]),
+	const char *realfnname, char s[L_tmpnam])
 {
 	static char static_tmpnam_buf[PATH_MAX]; /* used if s is NULL */
 	char tmpnam_buf[PATH_MAX];


### PR DESCRIPTION
Match declaration of tmpnam in glibc >= 2.34 or it will break building
against it:
https://github.com/sailfishos-mirror/glibc/commit/26492c0a14966c32c43cd6ca1d0dca5e62c6cfef

Tested against glibc 2.35 and glibc 2.30.