### PR TITLE
[modes] obs-rpm-build+pp: Move up tools prefix

### DIFF
--- a/modes/obs-rpm-build+pp/config.lua
+++ b/modes/obs-rpm-build+pp/config.lua
@@ -20,6 +20,7 @@ exec_policy_selection = {
 		 exec_policy_name = "Tools-python"},
 		{prefix = tools_prefix .. "/bin/python",
 		 exec_policy_name = "Tools-python"},
+                {prefix = tools, exec_policy_name = "Tools"},
 
                 -- the toolchain, if not from Tools:
                 {dir = sbox_target_toolchain_dir, exec_policy_name = "Toolchain"},
@@ -29,8 +30,6 @@ exec_policy_selection = {
 
                 -- the workspace directory is expected to contain target binaries:
                 {dir = sbox_user_workspace, exec_policy_name = "Target"},
-
-		{prefix = tools, exec_policy_name = "Tools"},
 
 		-- DEFAULT RULE (must exist):
 		{prefix = "/", exec_policy_name = "Host"}


### PR DESCRIPTION
If the tools prefix isn't moved up their is a chance that programs which should
be executed under the tools policy is run under the target because the path is
for example in the sbox_user_home.