### PR TITLE
[sb2] Use correct path when scanning ld.so.cache. JB#59434

### DIFF
--- a/utils/sb2
+++ b/utils/sb2
@@ -677,7 +677,7 @@ write_ld_library_path_replacement_to_exec_config()
 		# directory names, and remove duplicates:
 		dirs_in_cache=$($rootdir/sbin/ldconfig --print-cache \
 							-r "$rootdir" \
-							-C "$rootdir/etc/ld.so.cache" |
+							-C '/etc/ld.so.cache' |
 						sed --regexp-extended -n '/=>/ {s/.*=> (.*)/\1/;s|(.*)/.*$|\1|p}' |
 						sort | uniq)
 		ld_library_extras_from_cache=$dirs_in_cache


### PR DESCRIPTION
Paths for ldconfig is relative to the root passed with -r.