### PR TITLE
Fix implicit declaration of statx gate helper function and includes

### DIFF
--- a/execs/exec_map_script_interp.c
+++ b/execs/exec_map_script_interp.c
@@ -5,11 +5,13 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
-#include "mapping.h"
-#include "sb2.h"
+#include <config.h>
+
+#include <mapping.h>
+#include <sb2.h>
+
 #include "libsb2.h"
 #include "exported.h"
-
 #include "sb2_execs.h"
 
 /* A very straightforward conversion from Lua:

--- a/execs/exec_policy_ruletree.c
+++ b/execs/exec_policy_ruletree.c
@@ -5,13 +5,15 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
-#include "mapping.h"
-#include "sb2.h"
-#include "libsb2.h"
-#include "exported.h"
+#include <config.h>
 
 #include <sys/mman.h>
 
+#include <mapping.h>
+#include <sb2.h>
+
+#include "libsb2.h"
+#include "exported.h"
 #include "sb2_execs.h"
 
 /* Functions for accessing exec policy settings in the rule tree db.

--- a/execs/exec_policy_selection.c
+++ b/execs/exec_policy_selection.c
@@ -14,14 +14,18 @@
  *      { dir = "/directory/path", exec_policy_name = "policyname" }
 */
 
-#include "mapping.h"
-#include "sb2.h"
-#include "libsb2.h"
-#include "exported.h"
+#include <config.h>
 
 #include <sys/mman.h>
 
+#include <mapping.h>
+#include <sb2.h>
+
+#include "libsb2.h"
+#include "exported.h"
 #include "sb2_execs.h"
+
+
 
 /* FIXME: This is currently a slightly modified copy of ruletree_test_path_match()
  *    

--- a/execs/exec_postprocess.c
+++ b/execs/exec_postprocess.c
@@ -5,11 +5,13 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
-#include "mapping.h"
-#include "sb2.h"
+#include <config.h>
+
+#include <mapping.h>
+#include <sb2.h>
+
 #include "libsb2.h"
 #include "exported.h"
-
 #include "sb2_execs.h"
 
 /* Exec postprocessing for native, dynamically linked binaries.

--- a/execs/exec_preprocess.c
+++ b/execs/exec_preprocess.c
@@ -12,6 +12,7 @@
  * should be started (see description of the algorithm in sb_exec.c)
  * (this also typically adds, deletes, or modifies arguments whenever needed)
 */
+#include <config.h>
 
 #if 0
 #include <unistd.h>
@@ -39,14 +40,13 @@
 #include <sys/file.h>
 #include <assert.h>
 #endif
-
-#include "mapping.h"
-#include "sb2.h"
-#include "libsb2.h"
-#include "exported.h"
-
 #include <sys/mman.h>
 
+#include <mapping.h>
+#include <sb2.h>
+
+#include "libsb2.h"
+#include "exported.h"
 #include "sb2_execs.h"
 
 static int add_elements_to_argv(

--- a/execs/exec_ruletree_maint.c
+++ b/execs/exec_ruletree_maint.c
@@ -6,6 +6,8 @@
 
 /* Exec rule maintenance routines. */
 
+#include <config.h>
+
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,6 +18,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 
+#include <sys/mman.h>
 #ifdef _GNU_SOURCE
 #undef _GNU_SOURCE
 #include <string.h>
@@ -35,14 +38,14 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
-#include "mapping.h"
-#include "sb2.h"
+#include <mapping.h>
+#include <sb2.h>
+
 #include "libsb2.h"
 #include "exported.h"
-
-#include <sys/mman.h>
-
 #include "sb2_execs.h"
+
+
 
 /* "argvmods" rules: */
 ruletree_object_offset_t add_exec_preprocessing_rule_to_ruletree(

--- a/execs/sb_exec.c
+++ b/execs/sb_exec.c
@@ -93,6 +93,10 @@
  * (there are some minor execptions, see the code for further details)
 */
 
+#include <config.h>
+
+#include <elf.h>
+#include <mapping.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -109,19 +113,15 @@
 #include <sys/user.h>
 #include <sys/mman.h>
 
-#include <config.h>
 #include <sb2.h>
-#include <mapping.h>
-#include <elf.h>
+#include <sb2_stat.h>
+#include <sb2_vperm.h>
+#include <processclock.h>
+#include <rule_tree.h>
 
 #include "libsb2.h"
 #include "exported.h"
-#include "rule_tree.h"
-#include "processclock.h"
-
 #include "sb2_execs.h"
-#include "sb2_stat.h"
-#include "sb2_vperm.h"
 
 #ifndef ARRAY_SIZE
 # define ARRAY_SIZE(array) (sizeof (array) / sizeof ((array)[0]))

--- a/include/elf.h
+++ b/include/elf.h
@@ -20,6 +20,7 @@
 #ifndef _ELF_H
 #define	_ELF_H 1
 
+#include <sys/cdefs.h>
 //#include <features.h>
 
 __BEGIN_DECLS

--- a/include/rule_tree.h
+++ b/include/rule_tree.h
@@ -18,6 +18,8 @@
 #ifndef SB2_RULETREE_H__
 #define SB2_RULETREE_H__
 
+#include <stdint.h>
+
 /* object offset must be an unsigned type: */
 typedef uint32_t ruletree_object_offset_t;
 

--- a/luaif/sblib_luaif.c
+++ b/luaif/sblib_luaif.c
@@ -10,21 +10,22 @@
  * Interfaces to sblib functions from Lua.
 */
 
+#include <config.h>
+
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
-
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <ctype.h>
 
-#include "mapping.h"
-#include "sb2.h"
-#include "sb2_network.h"
+#include <mapping.h>
+#include <sblib_luaif.h>
+#include <sb2.h>
+#include <sb2_network.h>
+
 #include "libsb2.h"
 #include "exported.h"
-
-#include "sblib_luaif.h"
 
 /* "sb.log": interface from lua to the logging system.
  * Parameters:

--- a/network/net_rules.c
+++ b/network/net_rules.c
@@ -20,17 +20,20 @@
  * for every TCP packet (see "NETWORKING MODES" in sb2(1))
 */
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include <config.h>
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <ctype.h>
 
-#include "mapping.h"
-#include "sb2.h"
-#include "sb2_network.h"
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+#include <mapping.h>
+#include <sb2.h>
+#include <sb2_network.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/chrootgate.c
+++ b/preload/chrootgate.c
@@ -21,12 +21,15 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 
-#include "sb2.h"
-#include "sb2_stat.h"
+#include <sb2.h>
+#include <sb2_stat.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/execgates.c
+++ b/preload/execgates.c
@@ -26,13 +26,15 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <config.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <errno.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/fdpathdb.c
+++ b/preload/fdpathdb.c
@@ -20,6 +20,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  */
+
+#include <config.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/preload/gen-interface.pl
+++ b/preload/gen-interface.pl
@@ -1519,7 +1519,8 @@ if(defined $wrappers_c_output_file) {
 	$interface_functions_and_classes .= "\t{NULL, 0},\n};\n";
 	write_output_file($wrappers_c_output_file,
 		$file_header_comment.
-		'#include "libsb2.h"'."\n".
+        '#include <config.h>'."\n\n".
+        '#include "libsb2.h"'."\n".
 		$include_h_file.
 		$wrappers_c_buffer.
 		$interface_functions_and_classes);

--- a/preload/glob64.c
+++ b/preload/glob64.c
@@ -2,6 +2,8 @@
  * from glibc's sysdep/gnu/glob64.c.
 */
 
+#include <config.h>
+
 // Apple doesn't have 64bit dirent?
 #ifndef __APPLE__
 

--- a/preload/libsb2.c
+++ b/preload/libsb2.c
@@ -28,12 +28,14 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <config.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <signal.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/mempcpy.c
+++ b/preload/mempcpy.c
@@ -30,6 +30,8 @@ PORTABILITY
 
 	*/
 
+#include <config.h>
+
 //#include <_ansi.h>
 #include <stddef.h>
 #include <limits.h>

--- a/preload/miscgates.c
+++ b/preload/miscgates.c
@@ -24,15 +24,18 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <config.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <signal.h>
+
+#include <rule_tree.h>
+
 #include "libsb2.h"
 #include "exported.h"
-#include "rule_tree.h"
 
 #ifdef HAVE_FTS_H
 /* FIXME: why there was #if !defined(HAVE___OPENDIR2) around fts_open() ???? */

--- a/preload/network.c
+++ b/preload/network.c
@@ -25,17 +25,20 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <config.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <stddef.h>
+
+#include <sb2_network.h>
+
 #include "libsb2.h"
-#include "sb2_network.h"
 #include "exported.h"
 
 /* ---------- internal functions etc. ---------- */

--- a/preload/sb2context.c
+++ b/preload/sb2context.c
@@ -5,6 +5,8 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
+#include <config.h>
+
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -30,11 +32,12 @@
 #include <sys/file.h>
 #include <assert.h>
 
-#include "mapping.h"
-#include "sb2.h"
-#include "rule_tree.h"
-#include "sb2_network.h"
-#include "sb2_vperm.h"
+#include <mapping.h>
+#include <sb2.h>
+#include <rule_tree.h>
+#include <sb2_network.h>
+#include <sb2_vperm.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/sb_l10n.c
+++ b/preload/sb_l10n.c
@@ -17,6 +17,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
  */
+
+#include <config.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/preload/system.c
+++ b/preload/system.c
@@ -18,6 +18,8 @@
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
    02111-1307 USA.  */
 
+#include <config.h>
+
 #include <errno.h>
 #include <signal.h>
 #include <stddef.h>

--- a/preload/tmpnamegates.c
+++ b/preload/tmpnamegates.c
@@ -25,16 +25,18 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <config.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <signal.h>
+
 #include "libsb2.h"
 #include "exported.h"
 
-/* mkstemp() modifies "template". This locates the part which should be 
+/* mkstemp() modifies "template". This locates the part which should be
  * modified, and copies the modification back from mapped buffer (which
  * was modified by the real function) to callers buffer.
 */

--- a/preload/union_dirs.c
+++ b/preload/union_dirs.c
@@ -6,6 +6,8 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
+#include <config.h>
+
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/preload/vperm_filestatgates.c
+++ b/preload/vperm_filestatgates.c
@@ -21,6 +21,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
 
+#include <config.h>
+
 #include "sb2.h"
 #include "sb2_stat.h"
 #include "sb2_vperm.h"

--- a/preload/vperm_statfuncts.c
+++ b/preload/vperm_statfuncts.c
@@ -5,15 +5,18 @@
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
 
+#include <config.h>
+
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/sysmacros.h>
-#include "sb2.h"
-#include "sb2_stat.h"
-#include "sb2_vperm.h"
 
-#include "rule_tree.h"
+#include <sb2.h>
+#include <sb2_stat.h>
+#include <sb2_vperm.h>
+#include <rule_tree.h>
+
 #include "libsb2.h"
 #include "exported.h"
 

--- a/preload/vperm_statfuncts.c
+++ b/preload/vperm_statfuncts.c
@@ -119,7 +119,7 @@ int real_fstat64(int fd, struct stat64 *statbuf)
 
 /* return 0 if not modified, positive if something was virtualized.
  * only one of {buf,bufx,buf64} should be set; set the other ones to NULL */
-int i_virtualize_struct_stat_internal(
+static int i_virtualize_struct_stat_internal(
 	const char *realfnname
 	, struct stat *buf
 	, struct stat64 *buf64

--- a/preload/vperm_uid_gid_gates.c
+++ b/preload/vperm_uid_gid_gates.c
@@ -20,11 +20,13 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 */
+#include <config.h>
 
-#include "sb2.h"
+#include <sb2.h>
+#include <sb2_vperm.h>
+
 #include "libsb2.h"
 #include "exported.h"
-#include "sb2_vperm.h"
 
 
 static struct vperm_uids_gids_s {

--- a/sb2d/rule_tree_luaif.c
+++ b/sb2d/rule_tree_luaif.c
@@ -4,6 +4,7 @@
  *
  * Licensed under LGPL version 2.1, see top level LICENSE file for details.
  */
+#include <config.h>
 
 #include <unistd.h>
 #include <stdio.h>
@@ -37,10 +38,9 @@
 
 #include <mapping.h>
 #include <sb2.h>
+#include <rule_tree.h>
 
-#include "rule_tree.h"
 #include "rule_tree_lua.h"
-
 
 /* ensure that the rule tree has been mapped. */
 static int lua_sb_attach_ruletree(lua_State *l)

--- a/sb2d/ruletree_server.c
+++ b/sb2d/ruletree_server.c
@@ -17,6 +17,8 @@
  * memory-mapped file is an atomic operation.
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/sb2d/sb2d.c
+++ b/sb2d/sb2d.c
@@ -17,6 +17,7 @@
  * memory-mapped file is an atomic operation.
 */
 
+#include <config.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -35,6 +36,7 @@
 
 #include "sb2_server.h"
 #include "rule_tree_lua.h"
+
 
 /* globals */
 

--- a/sb2d/server_socket.c
+++ b/sb2d/server_socket.c
@@ -6,6 +6,7 @@
 */
 
 /* Rule tree server, server socket routines */
+#include <config.h>
 
 #include <stdio.h>
 #include <stdint.h>

--- a/wrappers/fakeroot.c
+++ b/wrappers/fakeroot.c
@@ -8,6 +8,8 @@
  * SB2 session, by using SB2's features.
 */
 
+#include <config.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
## Fix implicit declaration of statx gate helper function and includes
  - i_virtualize_struct_statx was only implicitly defined in
  vterm_statfuns.c as config.h which defines HAVE_STATX wasn't included.
  Consistently include config.h before any other header to avoid issues

## Fix expected ‘;’ before ‘typedef’
  - `sys/cdefs` wasn't included in the vendored copy of elf-utils elf.h

## Include missing type headers
 - Similarly as the earlier commit above but for stdint.h