### PR TITLE
Deduplicate "Path not found for FD" warning lines. Fixes JB#63711

### DIFF
--- a/utils/sb2-exitreport
+++ b/utils/sb2-exitreport
@@ -93,7 +93,10 @@ if [ -s "$SBOX_MAPPING_LOGFILE" ]; then
 			if [ -z "$SBOX_QUIET" ];  then
 				echo "Messages from sb2:"
 			fi
-			cat $SBOX_MAPPING_LOGFILE
+			# There can be hundreds of thousands of near-identical
+			# file mapping warnings, so let's deduplicate them first.
+			# This can reduce the 'WARNING' line count by over 98%.
+			cat $SBOX_MAPPING_LOGFILE | awk '!seen[gensub(/\[[[:digit:]\/-]+]/, "", 1)]++'
 			;;
 		(*)
 			# Larger log (maybe a debug log)


### PR DESCRIPTION
This removes the matching lines from the log, de-duplicates them and appends them back to the stripped log. This preserves the order of other messages in the log, but moves these to the end of it. The order of the matching lines should not matter anyway.

Using xulrunner-qt5 as an example, there were 464619 lines in the OBS build log in total, of which 322876 (69%) were warnings. Running `sort -u`only left 4852 (1.5%) lines. With this the total line count went down to 146595 (32.5%), which affects the log file size noticeably as well, from 48MB to 23MB in this case. Just printing the warning lines took 2min 45s, which should be reduced as well, down to a few seconds.