### PR TITLE
Update glob from glibc 2.42. JB#62519

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ PKG_CHECK_VAR(LUA_LIBDIR, [lua], [libdir],
 
 # Checks for header files.
 AC_HEADER_DIRENT
+AC_STRUCT_DIRENT_D_TYPE
 AC_CHECK_HEADERS([ \
 fcntl.h \
 fts.h \

--- a/preload/flexmember.h
+++ b/preload/flexmember.h
@@ -1,0 +1,63 @@
+/* Copied from glibc-2.42 to Scratchbox 2
+ *
+ * added from glibc's posix/flexmember.h:
+*/
+
+/* Sizes of structs with flexible array members.
+
+   Copyright 2016-2025 Free Software Foundation, Inc.
+
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <stddef.h>
+
+/* Nonzero multiple of alignment of TYPE, suitable for FLEXSIZEOF below.
+   On older platforms without _Alignof, use a pessimistic bound that is
+   safe in practice even if FLEXIBLE_ARRAY_MEMBER is 1.
+   On newer platforms, use _Alignof to get a tighter bound.  */
+
+#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 201112
+# define FLEXALIGNOF(type) (sizeof (type) & ~ (sizeof (type) - 1))
+#else
+# define FLEXALIGNOF(type) _Alignof (type)
+#endif
+
+/* Yield a properly aligned upper bound on the size of a struct of
+   type TYPE with a flexible array member named MEMBER that is
+   followed by N bytes of other data.  The result is suitable as an
+   argument to malloc.  For example:
+
+     struct s { int n; char d[FLEXIBLE_ARRAY_MEMBER]; };
+     struct s *p = malloc (FLEXSIZEOF (struct s, d, n * sizeof (char)));
+
+   FLEXSIZEOF (TYPE, MEMBER, N) is not simply (sizeof (TYPE) + N),
+   since FLEXIBLE_ARRAY_MEMBER may be 1 on pre-C11 platforms.  Nor is
+   it simply (offsetof (TYPE, MEMBER) + N), as that might yield a size
+   that causes malloc to yield a pointer that is not properly aligned
+   for TYPE; for example, if sizeof (int) == alignof (int) == 4,
+   malloc (offsetof (struct s, d) + 3 * sizeof (char)) is equivalent
+   to malloc (7) and might yield a pointer that is not a multiple of 4
+   (which means the pointer is not properly aligned for struct s),
+   whereas malloc (FLEXSIZEOF (struct s, d, 3 * sizeof (char))) is
+   equivalent to malloc (8) and must yield a pointer that is a
+   multiple of 4.
+
+   Yield a value less than N if and only if arithmetic overflow occurs.  */
+
+#define FLEXSIZEOF(type, member, n) \
+   ((offsetof (type, member) + FLEXALIGNOF (type) - 1 + (n)) \
+    & ~ (FLEXALIGNOF (type) - 1))

--- a/preload/glob.c
+++ b/preload/glob.c
@@ -1,11 +1,10 @@
-/* Copied from glibc-2.7 to Scratchbox 2, with minimal modifications
+/* Copied from glibc-2.42 to Scratchbox 2, with minimal modifications
  * (search for "SB2" in the code below)
  *
  * added from glibc's posix/glob.c:
 */
 
-/* Copyright (C) 1991-2002, 2003, 2004, 2005, 2006, 2007
-   Free Software Foundation, Inc.
+/* Copyright (C) 1991-2025 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -19,9 +18,18 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#ifndef _LIBC
+
+/* Don't use __attribute__ __nonnull__ in this compilation unit.  Otherwise gcc
+   optimizes away the pattern == NULL test below.  */
+# define _GL_ARG_NONNULL(params)
+
+/* # include <libc-config.h> SB2 */
+
+#endif
 
 #include <config.h>
 
@@ -35,148 +43,32 @@
 */
 #include <dirent.h>
 
-#ifndef __APPLE__
 #include <glob.h>
-#else /* SB2 - OS X Compat */
-/* Bugfix: Background: The Mac OS X support added a copy of "glob.h"
- * to SB2. That file causes problems with glob() on Linux; it is maybe
- * not the best possible idea to replace system's glob.h with something 
- * that might not be fully compatible (it seems that the copy of
- * glob.h was taken from an older version of glibc?)
- * So, the fix is that for Linux systems we'll continue to use the 
- * system's glob.h with our private copies of glob.c and glob64.c; glob.h
- * was not missing by accident, this setup was intentional.
- * I have renamed "glob.h" (the copy which was intended for the Mac OS X's)
- * to "sb2_mac_glob.h. However, I don't know the meaning of the following 
- * #include (since there is another #include below), so I might have broken 
- * things on Mac OS X, sorry...  2009-01-16/LTA
-*/
-#include <glob.h> /* included here for Mac OS X support */
-#endif
-
+#include <fcntl.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 #include <stddef.h>
-
-/* Outcomment the following line for production quality code.  */
-/* #define NDEBUG 1 */
+#include <stdint.h>
 #include <assert.h>
+#include <unistd.h>
 
-#include <stdio.h>		/* Needed on stupid SunOS for assert.  */
-
-#if !defined _LIBC || !defined GLOB_ONLY_P
-#if defined HAVE_UNISTD_H || defined _LIBC
-# include <unistd.h>
-# ifndef POSIX
-#  ifdef _POSIX_VERSION
-#   define POSIX
-#  endif
-# endif
+#if defined _WIN32 && ! defined __CYGWIN__
+# define WINDOWS32
 #endif
 
-#include <pwd.h>
+#ifndef WINDOWS32
+# include <pwd.h>
+#endif
 
 #include <errno.h>
 #ifndef __set_errno
 # define __set_errno(val) errno = (val)
 #endif
-
-#if defined HAVE_DIRENT_H || defined __GNU_LIBRARY__
-# include <dirent.h>
-# define NAMLEN(dirent) strlen((dirent)->d_name)
-#else
-# define dirent direct
-# define NAMLEN(dirent) (dirent)->d_namlen
-# ifdef HAVE_SYS_NDIR_H
-#  include <sys/ndir.h>
-# endif
-# ifdef HAVE_SYS_DIR_H
-#  include <sys/dir.h>
-# endif
-# ifdef HAVE_NDIR_H
-#  include <ndir.h>
-# endif
-# ifdef HAVE_VMSDIR_H
-#  include "vmsdir.h"
-# endif /* HAVE_VMSDIR_H */
-#endif
-
-/* In GNU systems, <dirent.h> defines this macro for us.  */
-#ifdef _D_NAMLEN
-# undef NAMLEN
-# define NAMLEN(d) _D_NAMLEN(d)
-#endif
-
-/* When used in the GNU libc the symbol _DIRENT_HAVE_D_TYPE is available
-   if the `d_type' member for `struct dirent' is available.
-   HAVE_STRUCT_DIRENT_D_TYPE plays the same role in GNULIB.  */
-#if defined _DIRENT_HAVE_D_TYPE || defined HAVE_STRUCT_DIRENT_D_TYPE
-/* True if the directory entry D must be of type T.  */
-# define DIRENT_MUST_BE(d, t)	((d)->d_type == (t))
-
-/* True if the directory entry D might be a symbolic link.  */
-# define DIRENT_MIGHT_BE_SYMLINK(d) \
-    ((d)->d_type == DT_UNKNOWN || (d)->d_type == DT_LNK)
-
-/* True if the directory entry D might be a directory.  */
-# define DIRENT_MIGHT_BE_DIR(d)	 \
-    ((d)->d_type == DT_DIR || DIRENT_MIGHT_BE_SYMLINK (d))
-
-#else /* !HAVE_D_TYPE */
-# define DIRENT_MUST_BE(d, t)		false
-# define DIRENT_MIGHT_BE_SYMLINK(d)	true
-# define DIRENT_MIGHT_BE_DIR(d)		true
-#endif /* HAVE_D_TYPE */
-
-/* If the system has the `struct dirent64' type we use it internally.  */
-#if defined _LIBC && !defined COMPILE_GLOB64
-# if defined HAVE_DIRENT_H || defined __GNU_LIBRARY__
-#  define CONVERT_D_NAMLEN(d64, d32)
-# else
-#  define CONVERT_D_NAMLEN(d64, d32) \
-  (d64)->d_namlen = (d32)->d_namlen;
-# endif
-
-# if (defined POSIX || defined WINDOWS32) && !defined __GNU_LIBRARY__
-#  define CONVERT_D_INO(d64, d32)
-# else
-#  define CONVERT_D_INO(d64, d32) \
-  (d64)->d_ino = (d32)->d_ino;
-# endif
-
-# ifdef _DIRENT_HAVE_D_TYPE
-#  define CONVERT_D_TYPE(d64, d32) \
-  (d64)->d_type = (d32)->d_type;
-# else
-#  define CONVERT_D_TYPE(d64, d32)
-# endif
-
-# define CONVERT_DIRENT_DIRENT64(d64, d32) \
-  memcpy ((d64)->d_name, (d32)->d_name, NAMLEN (d32) + 1);		      \
-  CONVERT_D_NAMLEN (d64, d32)						      \
-  CONVERT_D_INO (d64, d32)						      \
-  CONVERT_D_TYPE (d64, d32)
-#endif
-
-
-#if (defined POSIX || defined WINDOWS32) && !defined __GNU_LIBRARY__
-/* Posix does not require that the d_ino field be present, and some
-   systems do not provide it. */
-# define REAL_DIR_ENTRY(dp) 1
-#else
-# define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
-#endif /* POSIX */
-
+#include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
-
-/* NAME_MAX is usually defined in <dirent.h> or <limits.h>.  */
-#include <limits.h>
-#ifndef NAME_MAX
-# define NAME_MAX (sizeof (((struct dirent *) 0)->d_name))
-#endif
-
 #include <alloca.h>
 
 #ifdef _LIBC
@@ -185,147 +77,297 @@
 # define sysconf(id) __sysconf (id)
 # define closedir(dir) __closedir (dir)
 # define opendir(name) __opendir (name)
+# undef dirfd
+# define dirfd(str) __dirfd (str)
 # define readdir(str) __readdir64 (str)
 # define getpwnam_r(name, bufp, buf, len, res) \
-   __getpwnam_r (name, bufp, buf, len, res)
-# ifndef __stat64
-#  define __stat64(fname, buf) __xstat64 (_STAT_VER, fname, buf)
+    __getpwnam_r (name, bufp, buf, len, res)
+# ifndef struct_stat
+#  define struct_stat           struct stat
 # endif
-# define struct_stat64		struct stat64
+# ifndef struct_stat64
+#  define struct_stat64         struct stat64
+# endif
+# ifndef GLOB_LSTAT
+#  define GLOB_LSTAT            gl_lstat
+# endif
+# ifndef GLOB_FSTATAT64
+#  define GLOB_FSTATAT64        __fstatat64
+# endif
+# include <shlib-compat.h>
 #else /* !_LIBC */
-#if 0 /* SB2: use unistd.c */
-# include "getlogin_r.h"
-# include "mempcpy.h"
-# include "stat-macros.h"
-# include "strdup.h"
-#else
-# include <unistd.h>
-# define __libc_use_alloca(allocasize) (0)
-#endif
-# define __stat64(fname, buf)	stat (fname, buf)
-# define struct_stat64		struct stat
-#ifndef __stat /* SB2 */
-# define __stat(fname, buf)	stat (fname, buf)
-#endif
-#ifndef __alloca /* SB2 - OS X Compat */
-# define __alloca		alloca
-#endif
-#ifndef __readdir /* SB2 */
-# define __readdir		readdir
-#endif
-# define __readdir64		readdir64
-# define __glob_pattern_p	glob_pattern_p
-#endif /* _LIBC */
+
+# define FLEXIBLE_ARRAY_MEMBER /* SB2 */
+
+# ifndef __readdir64 /* SB2 */
+#  define __readdir64		readdir64
+# endif
+
+/* SB2: this is called "do_glob" / "do_glob64" in SB2,
+ * "glob" & "glob64" are the wrappers */
+# ifdef COMPILE_GLOB64
+#  define __glob do_glob64
+# else
+#  define __glob do_glob
+# endif
+
+# define __getlogin_r(buf, len) getlogin_r (buf, len)
+# define __fxstatat64(_, d, f, st, flag) fstatat (d, f, st, flag)
+# ifndef __alloca /* SB2 */
+#  define __alloca              alloca
+# endif
+# ifndef __readdir /* SB2 */
+#  define __readdir                readdir
+# endif
+# define struct_stat            struct stat
+# define struct_stat64          struct stat64
+# define GLOB_LSTAT             gl_lstat
+# define GLOB_FSTATAT64         fstatat64
+# endif /* _LIBC */
 
 #include <fnmatch.h>
 
-#ifdef _SC_GETPW_R_SIZE_MAX
-# define GETPW_R_SIZE_MAX()	sysconf (_SC_GETPW_R_SIZE_MAX)
-#else
-# define GETPW_R_SIZE_MAX()	(-1)
-#endif
-#ifdef _SC_LOGIN_NAME_MAX
-# define GET_LOGIN_NAME_MAX()	sysconf (_SC_LOGIN_NAME_MAX)
-#else
-# define GET_LOGIN_NAME_MAX()	(-1)
+#include <flexmember.h>
+#include <glob_internal.h>
+#include <scratch_buffer.h>
+
+#ifndef __THROWNL /* SB2 - OS X Compat */
+# define __THROWNL
 #endif
 
-#ifdef __APPLE__ /* SB2 - OS X Compat */
-# define __THROW
-# define __attribute_noinline__ __attribute__ ((__noinline__))
-#include <stdbool.h>
-//#include <dirent.h>
+static const char *next_brace_sub (const char *begin, int flags) __THROWNL;
+
+/* The type of ((struct dirent *) 0)->d_type is 'unsigned char' on most
+   platforms, but 'unsigned int' in the mingw from mingw.org.  */
+typedef uint_fast32_t dirent_type;
+
+#if !defined _LIBC && !defined HAVE_STRUCT_DIRENT_D_TYPE
+/* Any distinct values will do here.
+   Undef any existing macros out of the way.  */
+# undef DT_UNKNOWN
+# undef DT_DIR
+# undef DT_LNK
+# define DT_UNKNOWN 0
+# define DT_DIR 1
+# define DT_LNK 2
+#endif
+
+/* A representation of a directory entry which does not depend on the
+   layout of struct dirent, or the size of ino_t.  */
+struct readdir_result
+{
+  const char *name;
+#if defined _DIRENT_HAVE_D_TYPE || defined HAVE_STRUCT_DIRENT_D_TYPE
+  dirent_type type;
+#endif
+};
+
+/* Initialize and return type member of struct readdir_result.  */
+static dirent_type
+readdir_result_type (struct readdir_result d)
+{
+#if defined _DIRENT_HAVE_D_TYPE || defined HAVE_STRUCT_DIRENT_D_TYPE
+# define D_TYPE_TO_RESULT(source) (source)->d_type,
+  return d.type;
+#else
+# define D_TYPE_TO_RESULT(source)
+  return DT_UNKNOWN;
+#endif
+}
+
+/* Construct an initializer for a struct readdir_result object from a
+   struct dirent *.  No copy of the name is made.  */
+#define READDIR_RESULT_INITIALIZER(source) \
+  {                                        \
+    source->d_name,                        \
+    D_TYPE_TO_RESULT (source)              \
+  }
+
+/* Call gl_readdir on STREAM.  This macro can be overridden to reduce
+   type safety if an old interface version needs to be supported.  */
+#ifndef GL_READDIR
+# define GL_READDIR(pglob, stream) ((pglob)->gl_readdir (stream))
 #endif
 
 #ifndef HAVE_MEMPCPY /* SB2 - OS X Compat */
 #include <mempcpy.h>
 #endif
+/* Extract name and type from directory entry.  No copy of the name is
+   made.  If SOURCE is NULL, result name is NULL.  Keep in sync with
+   convert_dirent64 below.  */
+static struct readdir_result
+convert_dirent (const struct dirent *source)
+{
+  if (source == NULL)
+    {
+      struct readdir_result result = { NULL, };
+      return result;
+    }
+  struct readdir_result result = READDIR_RESULT_INITIALIZER (source);
+  return result;
+}
 
 #ifdef __APPLE__ /* SB2 - OS X Compat */
-#include "sb2_mac_glob.h" /* SB2 - OS X Compat */
+#include "sb2_mac_glob.h"
 #endif
 
-
-static const char *next_brace_sub (const char *begin, int flags) __THROW;
-
-#endif /* !defined _LIBC || !defined GLOB_ONLY_P */
-
-#ifndef attribute_hidden
-# define attribute_hidden
+#ifndef COMPILE_GLOB64
+/* Like convert_dirent, but works on struct dirent64 instead.  Keep in
+   sync with convert_dirent above.  */
+static struct readdir_result
+convert_dirent64 (const struct dirent64 *source)
+{
+  if (source == NULL)
+    {
+      struct readdir_result result = { NULL, };
+      return result;
+    }
+  struct readdir_result result = READDIR_RESULT_INITIALIZER (source);
+  return result;
+}
 #endif
+
+#ifndef _LIBC
+/* The results of opendir() in this file are not used with dirfd and fchdir,
+   and we do not leak fds to any single-threaded code that could use stdio,
+   therefore save some unnecessary recursion in fchdir.c and opendir_safer.c.
+   FIXME - if the kernel ever adds support for multi-thread safety for
+   avoiding standard fds, then we should use opendir_safer.  */
+# ifdef GNULIB_defined_opendir
+#  undef opendir
+# endif
+# ifdef GNULIB_defined_closedir
+#  undef closedir
+# endif
+
+/* Just use malloc.  */
+# define __libc_use_alloca(n) false
+# define alloca_account(len, avar) ((void) (len), (void) (avar), (void *) 0)
+# define extend_alloca_account(buf, len, newlen, avar) \
+    ((void) (buf), (void) (len), (void) (newlen), (void) (avar), (void *) 0)
+#endif
+
+static int
+glob_lstat (glob_t *pglob, int flags, const char *fullname)
+{
+/* Use on glob-lstat-compat.c to provide a compat symbol which does not
+   use lstat / gl_lstat.  */
+  union
+  {
+    struct_stat st;
+    struct_stat64 st64;
+  } ust;
+  return (__glibc_unlikely (flags & GLOB_ALTDIRFUNC)
+          ? pglob->GLOB_LSTAT (fullname, &ust.st)
+          : GLOB_FSTATAT64 (AT_FDCWD, fullname, &ust.st64,
+                            AT_SYMLINK_NOFOLLOW));
+}
+
+/* Set *R = A + B.  Return true if the answer is mathematically
+   incorrect due to overflow; in this case, *R is the low order
+   bits of the correct answer.  */
+
+static bool
+size_add_wrapv (size_t a, size_t b, size_t *r)
+{
+#if 7 <= __GNUC__ && !defined __ICC
+  return __builtin_add_overflow (a, b, r);
+#else
+  *r = a + b;
+  return *r < a;
+#endif
+}
+
+static bool
+glob_use_alloca (size_t alloca_used, size_t len)
+{
+  size_t size;
+  return (!size_add_wrapv (alloca_used, len, &size)
+          && __libc_use_alloca (size));
+}
 
 static int glob_in_dir (const char *pattern, const char *directory,
-			int flags, int (*errfunc) (const char *, int),
-			glob_t *pglob);
-extern int __glob_pattern_type (const char *pattern, int quote)
-    attribute_hidden;
+                        int flags, int (*errfunc) (const char *, int),
+                        glob_t *pglob, size_t alloca_used);
+/* SB2 - already defined
+ * extern int __glob_pattern_type (const char *pattern, int quote)
+ *     attribute_hidden;
+ */
 
-#if !defined _LIBC || !defined GLOB_ONLY_P
-static int prefix_array (const char *prefix, char **array, size_t n) __THROW;
-static int collated_compare (const void *, const void *) __THROW;
+static int prefix_array (const char *prefix, char **array, size_t n) __THROWNL;
+static int collated_compare (const void *, const void *) __THROWNL;
 
+
+/* Return true if FILENAME is a directory or a symbolic link to a directory.
+   Use FLAGS and PGLOB to resolve the filename.  */
+static bool
+is_dir (char const *filename, int flags, glob_t const *pglob)
+{
+  struct_stat st;
+  struct_stat64 st64;
+  return (__glibc_unlikely (flags & GLOB_ALTDIRFUNC)
+          ? pglob->gl_stat (filename, &st) == 0 && S_ISDIR (st.st_mode)
+          : (GLOB_FSTATAT64 (AT_FDCWD, filename, &st64, 0) == 0
+             && S_ISDIR (st64.st_mode)));;
+}
 
 /* Find the end of the sub-pattern in a brace expression.  */
 static const char *
 next_brace_sub (const char *cp, int flags)
 {
-  unsigned int depth = 0;
+  size_t depth = 0;
   while (*cp != '\0')
     if ((flags & GLOB_NOESCAPE) == 0 && *cp == '\\')
       {
-	if (*++cp == '\0')
-	  break;
-	++cp;
+        if (*++cp == '\0')
+          break;
+        ++cp;
       }
     else
       {
-	if ((*cp == '}' && depth-- == 0) || (*cp == ',' && depth == 0))
-	  break;
+        if ((*cp == '}' && depth-- == 0) || (*cp == ',' && depth == 0))
+          break;
 
-	if (*cp++ == '{')
-	  depth++;
+        if (*cp++ == '{')
+          depth++;
       }
 
   return *cp != '\0' ? cp : NULL;
 }
 
-#endif /* !defined _LIBC || !defined GLOB_ONLY_P */
+#ifndef GLOB_ATTRIBUTE
+# define GLOB_ATTRIBUTE
+#endif
+
+int
+GLOB_ATTRIBUTE
+__glob (const char *pattern, int flags, int (*errfunc) (const char *, int),
+        glob_t *pglob);
 
 /* Do glob searching for PATTERN, placing results in PGLOB.
    The bits defined above may be set in FLAGS.
    If a directory cannot be opened or read and ERRFUNC is not nil,
    it is called with the pathname that caused the error, and the
-   `errno' value from the failing call; if it returns non-zero
-   `glob' returns GLOB_ABORTED; if it returns zero, the error is ignored.
+   'errno' value from the failing call; if it returns non-zero
+   'glob' returns GLOB_ABORTED; if it returns zero, the error is ignored.
    If memory cannot be allocated for PGLOB, GLOB_NOSPACE is returned.
-   Otherwise, `glob' returns zero.  */
-#if 1 /* SB2 */
-/* this is called "do_glob" / "do_glob64" in SB2,
- * "glob" & "glob64" are the wrappers */
-# ifdef COMPILE_GLOB64
-#  define glob do_glob64
-# else
-#  define glob do_glob
-# endif
-#endif
+   Otherwise, 'glob' returns zero.  */
 int
-#ifdef GLOB_ATTRIBUTE
 GLOB_ATTRIBUTE
-#endif
-glob (pattern, flags, errfunc, pglob)
-     const char *pattern;
-     int flags;
-     int (*errfunc) (const char *, int);
-     glob_t *pglob;
+__glob (const char *pattern, int flags, int (*errfunc) (const char *, int),
+        glob_t *pglob)
 {
   const char *filename;
-  const char *dirname;
+  char *dirname = NULL;
   size_t dirlen;
   int status;
   size_t oldcount;
   int meta;
   int dirname_modified;
+  int malloc_dirname = 0;
   glob_t dirs;
+  int retval = 0;
+  size_t alloca_used = 0;
 
   if (pattern == NULL || pglob == NULL || (flags & ~__GLOB_FLAGS) != 0)
     {
@@ -333,199 +375,217 @@ glob (pattern, flags, errfunc, pglob)
       return -1;
     }
 
+  /* POSIX requires all slashes to be matched.  This means that with
+     a trailing slash we must match only directories.  */
+  if (pattern[0] && pattern[strlen (pattern) - 1] == '/')
+    flags |= GLOB_ONLYDIR;
+
   if (!(flags & GLOB_DOOFFS))
-    /* Have to do this so `globfree' knows where to start freeing.  It
+    /* Have to do this so 'globfree' knows where to start freeing.  It
        also makes all the code that uses gl_offs simpler. */
     pglob->gl_offs = 0;
+
+  if (!(flags & GLOB_APPEND))
+    {
+      pglob->gl_pathc = 0;
+      if (!(flags & GLOB_DOOFFS))
+        pglob->gl_pathv = NULL;
+      else
+        {
+          size_t i;
+
+          if (pglob->gl_offs >= ~((size_t) 0) / sizeof (char *))
+            return GLOB_NOSPACE;
+
+          pglob->gl_pathv = (char **) malloc ((pglob->gl_offs + 1)
+                                              * sizeof (char *));
+          if (pglob->gl_pathv == NULL)
+            return GLOB_NOSPACE;
+
+          for (i = 0; i <= pglob->gl_offs; ++i)
+            pglob->gl_pathv[i] = NULL;
+        }
+    }
 
   if (flags & GLOB_BRACE)
     {
       const char *begin;
 
       if (flags & GLOB_NOESCAPE)
-	begin = strchr (pattern, '{');
+        begin = strchr (pattern, '{');
       else
-	{
-	  begin = pattern;
-	  while (1)
-	    {
-	      if (*begin == '\0')
-		{
-		  begin = NULL;
-		  break;
-		}
+        {
+          begin = pattern;
+          while (1)
+            {
+              if (*begin == '\0')
+                {
+                  begin = NULL;
+                  break;
+                }
 
-	      if (*begin == '\\' && begin[1] != '\0')
-		++begin;
-	      else if (*begin == '{')
-		break;
+              if (*begin == '\\' && begin[1] != '\0')
+                ++begin;
+              else if (*begin == '{')
+                break;
 
-	      ++begin;
-	    }
-	}
+              ++begin;
+            }
+        }
 
       if (begin != NULL)
-	{
-	  /* Allocate working buffer large enough for our work.  Note that
-	    we have at least an opening and closing brace.  */
-	  size_t firstc;
-	  char *alt_start;
-	  const char *p;
-	  const char *next;
-	  const char *rest;
-	  size_t rest_len;
-#ifdef __GNUC__
-	  char onealt[strlen (pattern) - 1];
-#else
-	  char *onealt = (char *) malloc (strlen (pattern) - 1);
-	  if (onealt == NULL)
-	    {
-	      if (!(flags & GLOB_APPEND))
-		{
-		  pglob->gl_pathc = 0;
-		  pglob->gl_pathv = NULL;
-		}
-	      return GLOB_NOSPACE;
-	    }
-#endif
+        {
+          /* Allocate working buffer large enough for our work.  Note that
+            we have at least an opening and closing brace.  */
+          size_t firstc;
+          char *alt_start;
+          const char *p;
+          const char *next;
+          const char *rest;
+          size_t rest_len;
+          char *onealt;
+          size_t pattern_len = strlen (pattern) - 1;
+          int alloca_onealt = glob_use_alloca (alloca_used, pattern_len);
+          if (alloca_onealt)
+            onealt = alloca_account (pattern_len, alloca_used);
+          else
+            {
+              onealt = malloc (pattern_len);
+              if (onealt == NULL)
+                return GLOB_NOSPACE;
+            }
 
-	  /* We know the prefix for all sub-patterns.  */
-	  alt_start = mempcpy (onealt, pattern, begin - pattern);
+          /* We know the prefix for all sub-patterns.  */
+          alt_start = mempcpy (onealt, pattern, begin - pattern);
 
-	  /* Find the first sub-pattern and at the same time find the
-	     rest after the closing brace.  */
-	  next = next_brace_sub (begin + 1, flags);
-	  if (next == NULL)
-	    {
-	      /* It is an illegal expression.  */
-#ifndef __GNUC__
-	      free (onealt);
-#endif
-	      return glob (pattern, flags & ~GLOB_BRACE, errfunc, pglob);
-	    }
+          /* Find the first sub-pattern and at the same time find the
+             rest after the closing brace.  */
+          next = next_brace_sub (begin + 1, flags);
+          if (next == NULL)
+            {
+              /* It is an invalid expression.  */
+            illegal_brace:
+              if (__glibc_unlikely (!alloca_onealt))
+                free (onealt);
+              flags &= ~GLOB_BRACE;
+              goto no_brace;
+            }
 
-	  /* Now find the end of the whole brace expression.  */
-	  rest = next;
-	  while (*rest != '}')
-	    {
-	      rest = next_brace_sub (rest + 1, flags);
-	      if (rest == NULL)
-		{
-		  /* It is an illegal expression.  */
-#ifndef __GNUC__
-		  free (onealt);
-#endif
-		  return glob (pattern, flags & ~GLOB_BRACE, errfunc, pglob);
-		}
-	    }
-	  /* Please note that we now can be sure the brace expression
-	     is well-formed.  */
-	  rest_len = strlen (++rest) + 1;
+          /* Now find the end of the whole brace expression.  */
+          rest = next;
+          while (*rest != '}')
+            {
+              rest = next_brace_sub (rest + 1, flags);
+              if (rest == NULL)
+                /* It is an illegal expression.  */
+                goto illegal_brace;
+            }
+          /* Please note that we now can be sure the brace expression
+             is well-formed.  */
+          rest_len = strlen (++rest) + 1;
 
-	  /* We have a brace expression.  BEGIN points to the opening {,
-	     NEXT points past the terminator of the first element, and END
-	     points past the final }.  We will accumulate result names from
-	     recursive runs for each brace alternative in the buffer using
-	     GLOB_APPEND.  */
+          /* We have a brace expression.  BEGIN points to the opening {,
+             NEXT points past the terminator of the first element, and END
+             points past the final }.  We will accumulate result names from
+             recursive runs for each brace alternative in the buffer using
+             GLOB_APPEND.  */
+          firstc = pglob->gl_pathc;
 
-	  if (!(flags & GLOB_APPEND))
-	    {
-	      /* This call is to set a new vector, so clear out the
-		 vector so we can append to it.  */
-	      pglob->gl_pathc = 0;
-	      pglob->gl_pathv = NULL;
-	    }
-	  firstc = pglob->gl_pathc;
+          p = begin + 1;
+          while (1)
+            {
+              int result;
 
-	  p = begin + 1;
-	  while (1)
-	    {
-	      int result;
+              /* Construct the new glob expression.  */
+              mempcpy (mempcpy (alt_start, p, next - p), rest, rest_len);
 
-	      /* Construct the new glob expression.  */
-	      mempcpy (mempcpy (alt_start, p, next - p), rest, rest_len);
+              result = __glob (onealt,
+                               ((flags & ~(GLOB_NOCHECK | GLOB_NOMAGIC))
+                                | GLOB_APPEND),
+                               errfunc, pglob);
 
-	      result = glob (onealt,
-			     ((flags & ~(GLOB_NOCHECK | GLOB_NOMAGIC))
-			      | GLOB_APPEND), errfunc, pglob);
+              /* If we got an error, return it.  */
+              if (result && result != GLOB_NOMATCH)
+                {
+                  if (__glibc_unlikely (!alloca_onealt))
+                    free (onealt);
+                  if (!(flags & GLOB_APPEND))
+                    {
+                      globfree (pglob);
+                      pglob->gl_pathc = 0;
+                    }
+                  return result;
+                }
 
-	      /* If we got an error, return it.  */
-	      if (result && result != GLOB_NOMATCH)
-		{
-#ifndef __GNUC__
-		  free (onealt);
-#endif
-		  if (!(flags & GLOB_APPEND))
-		    {
-		      globfree (pglob);
-		      pglob->gl_pathc = 0;
-		    }
-		  return result;
-		}
+              if (*next == '}')
+                /* We saw the last entry.  */
+                break;
 
-	      if (*next == '}')
-		/* We saw the last entry.  */
-		break;
+              p = next + 1;
+              next = next_brace_sub (p, flags);
+              assert (next != NULL);
+            }
 
-	      p = next + 1;
-	      next = next_brace_sub (p, flags);
-	      assert (next != NULL);
-	    }
+          if (__glibc_unlikely (!alloca_onealt))
+            free (onealt);
 
-#ifndef __GNUC__
-	  free (onealt);
-#endif
-
-	  if (pglob->gl_pathc != firstc)
-	    /* We found some entries.  */
-	    return 0;
-	  else if (!(flags & (GLOB_NOCHECK|GLOB_NOMAGIC)))
-	    return GLOB_NOMATCH;
-	}
+          if (pglob->gl_pathc != firstc)
+            /* We found some entries.  */
+            return 0;
+          else if (!(flags & (GLOB_NOCHECK|GLOB_NOMAGIC)))
+            return GLOB_NOMATCH;
+        }
     }
+
+ no_brace:
+  oldcount = pglob->gl_pathc + pglob->gl_offs;
 
   /* Find the filename.  */
   filename = strrchr (pattern, '/');
+
 #if defined __MSDOS__ || defined WINDOWS32
-  /* The case of "d:pattern".  Since `:' is not allowed in
+  /* The case of "d:pattern".  Since ':' is not allowed in
      file names, we can safely assume that wherever it
      happens in pattern, it signals the filename part.  This
      is so we could some day support patterns like "[a-z]:foo".  */
   if (filename == NULL)
     filename = strchr (pattern, ':');
 #endif /* __MSDOS__ || WINDOWS32 */
+
   dirname_modified = 0;
   if (filename == NULL)
     {
       /* This can mean two things: a simple name or "~name".  The latter
-	 case is nothing but a notation for a directory.  */
+         case is nothing but a notation for a directory.  */
       if ((flags & (GLOB_TILDE|GLOB_TILDE_CHECK)) && pattern[0] == '~')
-	{
-	  dirname = pattern;
-	  dirlen = strlen (pattern);
+        {
+          dirname = (char *) pattern;
+          dirlen = strlen (pattern);
 
-	  /* Set FILENAME to NULL as a special flag.  This is ugly but
-	     other solutions would require much more code.  We test for
-	     this special case below.  */
-	  filename = NULL;
-	}
+          /* Set FILENAME to NULL as a special flag.  This is ugly but
+             other solutions would require much more code.  We test for
+             this special case below.  */
+          filename = NULL;
+        }
       else
-	{
-	  filename = pattern;
-#ifdef _AMIGA
-	  dirname = "";
-#else
-	  dirname = ".";
-#endif
-	  dirlen = 0;
-	}
+        {
+          if (__glibc_unlikely (pattern[0] == '\0'))
+            {
+              dirs.gl_pathv = NULL;
+              goto no_matches;
+            }
+
+          filename = pattern;
+          dirname = (char *) ".";
+          dirlen = 0;
+        }
     }
   else if (filename == pattern
-	   || (filename == pattern + 1 && pattern[0] == '\\'
-	       && (flags & GLOB_NOESCAPE) == 0))
+           || (filename == pattern + 1 && pattern[0] == '\\'
+               && (flags & GLOB_NOESCAPE) == 0))
     {
       /* "/pattern" or "\\/pattern".  */
-      dirname = "/";
+      dirname = (char *) "/";
       dirlen = 1;
       ++filename;
     }
@@ -535,357 +595,424 @@ glob (pattern, flags, errfunc, pglob)
       dirlen = filename - pattern;
 #if defined __MSDOS__ || defined WINDOWS32
       if (*filename == ':'
-	  || (filename > pattern + 1 && filename[-1] == ':'))
-	{
-	  char *drive_spec;
+          || (filename > pattern + 1 && filename[-1] == ':'))
+        {
+          char *drive_spec;
 
-	  ++dirlen;
-	  drive_spec = (char *) __alloca (dirlen + 1);
-	  *((char *) mempcpy (drive_spec, pattern, dirlen)) = '\0';
-	  /* For now, disallow wildcards in the drive spec, to
-	     prevent infinite recursion in glob.  */
-	  if (__glob_pattern_p (drive_spec, !(flags & GLOB_NOESCAPE)))
-	    return GLOB_NOMATCH;
-	  /* If this is "d:pattern", we need to copy `:' to DIRNAME
-	     as well.  If it's "d:/pattern", don't remove the slash
-	     from "d:/", since "d:" and "d:/" are not the same.*/
-	}
+          ++dirlen;
+          drive_spec = __alloca (dirlen + 1);
+          *((char *) mempcpy (drive_spec, pattern, dirlen)) = '\0';
+          /* For now, disallow wildcards in the drive spec, to
+             prevent infinite recursion in glob.  */
+          if (__glob_pattern_p (drive_spec, !(flags & GLOB_NOESCAPE)))
+            return GLOB_NOMATCH;
+          /* If this is "d:pattern", we need to copy ':' to DIRNAME
+             as well.  If it's "d:/pattern", don't remove the slash
+             from "d:/", since "d:" and "d:/" are not the same.*/
+        }
 #endif
-      newp = (char *) __alloca (dirlen + 1);
+
+      if (glob_use_alloca (alloca_used, dirlen + 1))
+        newp = alloca_account (dirlen + 1, alloca_used);
+      else
+        {
+          newp = malloc (dirlen + 1);
+          if (newp == NULL)
+            return GLOB_NOSPACE;
+          malloc_dirname = 1;
+        }
       *((char *) mempcpy (newp, pattern, dirlen)) = '\0';
       dirname = newp;
       ++filename;
 
-      if (filename[0] == '\0'
 #if defined __MSDOS__ || defined WINDOWS32
-          && dirname[dirlen - 1] != ':'
-	  && (dirlen < 3 || dirname[dirlen - 2] != ':'
-	      || dirname[dirlen - 1] != '/')
+      bool drive_root = (dirlen > 1
+                         && (dirname[dirlen - 1] == ':'
+                             || (dirlen > 2 && dirname[dirlen - 2] == ':'
+                                 && dirname[dirlen - 1] == '/')));
+#else
+      bool drive_root = false;
 #endif
-	  && dirlen > 1)
-	/* "pattern/".  Expand "pattern", appending slashes.  */
-	{
-	  int orig_flags = flags;
-	  if (!(flags & GLOB_NOESCAPE) && dirname[dirlen - 1] == '\\')
-	    {
-	      /* "pattern\\/".  Remove the final backslash if it hasn't
-		 been quoted.  */
-	      char *p = (char *) &dirname[dirlen - 1];
 
-	      while (p > dirname && p[-1] == '\\') --p;
-	      if ((&dirname[dirlen] - p) & 1)
-		{
-		  *(char *) &dirname[--dirlen] = '\0';
-		  flags &= ~(GLOB_NOCHECK | GLOB_NOMAGIC);
-		}
-	    }
-	  int val = glob (dirname, flags | GLOB_MARK, errfunc, pglob);
-	  if (val == 0)
-	    pglob->gl_flags = ((pglob->gl_flags & ~GLOB_MARK)
-			       | (flags & GLOB_MARK));
-	  else if (val == GLOB_NOMATCH && flags != orig_flags)
-	    {
-	      /* Make sure globfree (&dirs); is a nop.  */
-	      dirs.gl_pathv = NULL;
-	      flags = orig_flags;
-	      oldcount = pglob->gl_pathc + pglob->gl_offs;
-	      goto no_matches;
-	    }
-	  return val;
-	}
+      if (filename[0] == '\0' && dirlen > 1 && !drive_root)
+        /* "pattern/".  Expand "pattern", appending slashes.  */
+        {
+          int orig_flags = flags;
+          if (!(flags & GLOB_NOESCAPE) && dirname[dirlen - 1] == '\\')
+            {
+              /* "pattern\\/".  Remove the final backslash if it hasn't
+                 been quoted.  */
+              char *p = (char *) &dirname[dirlen - 1];
+
+              while (p > dirname && p[-1] == '\\') --p;
+              if ((&dirname[dirlen] - p) & 1)
+                {
+                  *(char *) &dirname[--dirlen] = '\0';
+                  flags &= ~(GLOB_NOCHECK | GLOB_NOMAGIC);
+                }
+            }
+          int val = __glob (dirname, flags | GLOB_MARK, errfunc, pglob);
+          if (val == 0)
+            pglob->gl_flags = ((pglob->gl_flags & ~GLOB_MARK)
+                               | (flags & GLOB_MARK));
+          else if (val == GLOB_NOMATCH && flags != orig_flags)
+            {
+              /* Make sure globfree (&dirs); is a nop.  */
+              dirs.gl_pathv = NULL;
+              flags = orig_flags;
+              oldcount = pglob->gl_pathc + pglob->gl_offs;
+              goto no_matches;
+            }
+          retval = val;
+          goto out;
+        }
     }
 
-  if (!(flags & GLOB_APPEND))
-    {
-      pglob->gl_pathc = 0;
-      if (!(flags & GLOB_DOOFFS))
-        pglob->gl_pathv = NULL;
-      else
-	{
-	  size_t i;
-	  pglob->gl_pathv = (char **) malloc ((pglob->gl_offs + 1)
-					      * sizeof (char *));
-	  if (pglob->gl_pathv == NULL)
-	    return GLOB_NOSPACE;
-
-	  for (i = 0; i <= pglob->gl_offs; ++i)
-	    pglob->gl_pathv[i] = NULL;
-	}
-    }
-
-  oldcount = pglob->gl_pathc + pglob->gl_offs;
-
-#ifndef VMS
   if ((flags & (GLOB_TILDE|GLOB_TILDE_CHECK)) && dirname[0] == '~')
     {
       if (dirname[1] == '\0' || dirname[1] == '/'
-	  || (!(flags & GLOB_NOESCAPE) && dirname[1] == '\\'
-	      && (dirname[2] == '\0' || dirname[2] == '/')))
-	{
-	  /* Look up home directory.  */
-	  const char *home_dir = getenv ("HOME");
-# ifdef _AMIGA
-	  if (home_dir == NULL || home_dir[0] == '\0')
-	    home_dir = "SYS:";
+          || (!(flags & GLOB_NOESCAPE) && dirname[1] == '\\'
+              && (dirname[2] == '\0' || dirname[2] == '/')))
+        {
+          /* Look up home directory.  */
+          char *home_dir = getenv ("HOME");
+          int malloc_home_dir = 0;
+          if (home_dir == NULL || home_dir[0] == '\0')
+            {
+#ifdef WINDOWS32
+              /* Windows NT defines HOMEDRIVE and HOMEPATH.  But give
+                 preference to HOME, because the user can change HOME.  */
+              const char *home_drive = getenv ("HOMEDRIVE");
+              const char *home_path = getenv ("HOMEPATH");
+
+              if (home_drive != NULL && home_path != NULL)
+                {
+                  size_t home_drive_len = strlen (home_drive);
+                  size_t home_path_len = strlen (home_path);
+                  char *mem = alloca (home_drive_len + home_path_len + 1);
+
+                  memcpy (mem, home_drive, home_drive_len);
+                  memcpy (mem + home_drive_len, home_path, home_path_len + 1);
+                  home_dir = mem;
+                }
+              else
+                home_dir = "c:/users/default"; /* poor default */
+#else
+              int err;
+              struct passwd *p;
+              struct passwd pwbuf;
+              struct scratch_buffer s;
+              scratch_buffer_init (&s);
+              while (true)
+                {
+                  p = NULL;
+                  err = __getlogin_r (s.data, s.length);
+                  if (err == 0)
+                    {
+# if defined HAVE_GETPWNAM_R || defined _LIBC
+                      size_t ssize = strlen (s.data) + 1;
+                      err = getpwnam_r (s.data, &pwbuf, s.data + ssize,
+                                        s.length - ssize, &p);
 # else
-#  ifdef WINDOWS32
-	  if (home_dir == NULL || home_dir[0] == '\0')
-            home_dir = "c:/users/default"; /* poor default */
-#  else
-	  if (home_dir == NULL || home_dir[0] == '\0')
-	    {
-	      int success;
-	      char *name;
-	      size_t buflen = GET_LOGIN_NAME_MAX () + 1;
-
-	      if (buflen == 0)
-		/* `sysconf' does not support _SC_LOGIN_NAME_MAX.  Try
-		   a moderate value.  */
-		buflen = 20;
-	      name = (char *) __alloca (buflen);
-
-	      success = getlogin_r (name, buflen) == 0;
-	      if (success)
-		{
-		  struct passwd *p;
-#   if defined HAVE_GETPWNAM_R || defined _LIBC
-		  long int pwbuflen = GETPW_R_SIZE_MAX ();
-		  char *pwtmpbuf;
-		  struct passwd pwbuf;
-		  int save = errno;
-
-#    ifndef _LIBC
-		  if (pwbuflen == -1)
-		    /* `sysconf' does not support _SC_GETPW_R_SIZE_MAX.
-		       Try a moderate value.  */
-		    pwbuflen = 1024;
-#    endif
-		  pwtmpbuf = (char *) __alloca (pwbuflen);
-
-		  while (getpwnam_r (name, &pwbuf, pwtmpbuf, pwbuflen, &p)
-			 != 0)
-		    {
-		      if (errno != ERANGE)
-			{
-			  p = NULL;
-			  break;
-			}
-#    ifdef _LIBC
-		      pwtmpbuf = extend_alloca (pwtmpbuf, pwbuflen,
-						2 * pwbuflen);
-#    else
-		      pwbuflen *= 2;
-		      pwtmpbuf = (char *) __alloca (pwbuflen);
-#    endif
-		      __set_errno (save);
-		    }
-#   else
-		  p = getpwnam (name);
-#   endif
-		  if (p != NULL)
-		    home_dir = p->pw_dir;
-		}
-	    }
-	  if (home_dir == NULL || home_dir[0] == '\0')
-	    {
-	      if (flags & GLOB_TILDE_CHECK)
-		return GLOB_NOMATCH;
-	      else
-		home_dir = "~"; /* No luck.  */
-	    }
-#  endif /* WINDOWS32 */
+                      (void) pwbuf; /* SB2 */
+                      p = getpwnam (s.data);
+                      if (p == NULL)
+                        err = errno;
 # endif
-	  /* Now construct the full directory.  */
-	  if (dirname[1] == '\0')
-	    {
-	      dirname = home_dir;
-	      dirlen = strlen (dirname);
-	    }
-	  else
-	    {
-	      char *newp;
-	      size_t home_len = strlen (home_dir);
-	      newp = (char *) __alloca (home_len + dirlen);
-	      mempcpy (mempcpy (newp, home_dir, home_len),
-		       &dirname[1], dirlen);
-	      dirname = newp;
-	      dirlen += home_len - 1;
-	    }
-	  dirname_modified = 1;
-	}
-# if !defined _AMIGA && !defined WINDOWS32
+                    }
+                  if (err != ERANGE)
+                    break;
+                  if (!scratch_buffer_grow (&s))
+                    {
+                      retval = GLOB_NOSPACE;
+                      goto out;
+                    }
+                }
+              if (err == 0)
+                {
+                  home_dir = strdup (p->pw_dir);
+                  malloc_home_dir = 1;
+                }
+              scratch_buffer_free (&s);
+              if (err == 0 && home_dir == NULL)
+                {
+                  retval = GLOB_NOSPACE;
+                  goto out;
+                }
+#endif /* WINDOWS32 */
+            }
+          if (home_dir == NULL || home_dir[0] == '\0')
+            {
+              if (__glibc_unlikely (malloc_home_dir))
+                free (home_dir);
+              if (flags & GLOB_TILDE_CHECK)
+                {
+                  retval = GLOB_NOMATCH;
+                  goto out;
+                }
+              else
+                {
+                  home_dir = (char *) "~"; /* No luck.  */
+                  malloc_home_dir = 0;
+                }
+            }
+          /* Now construct the full directory.  */
+          if (dirname[1] == '\0')
+            {
+              if (__glibc_unlikely (malloc_dirname))
+                free (dirname);
+
+              dirname = home_dir;
+              dirlen = strlen (dirname);
+              malloc_dirname = malloc_home_dir;
+            }
+          else
+            {
+              char *newp;
+              size_t home_len = strlen (home_dir);
+              int use_alloca = glob_use_alloca (alloca_used, home_len + dirlen);
+              if (use_alloca)
+                newp = alloca_account (home_len + dirlen, alloca_used);
+              else
+                {
+                  newp = malloc (home_len + dirlen);
+                  if (newp == NULL)
+                    {
+                      if (__glibc_unlikely (malloc_home_dir))
+                        free (home_dir);
+                      retval = GLOB_NOSPACE;
+                      goto out;
+                    }
+                }
+
+              mempcpy (mempcpy (newp, home_dir, home_len),
+                       &dirname[1], dirlen);
+
+              if (__glibc_unlikely (malloc_dirname))
+                free (dirname);
+
+              dirname = newp;
+              dirlen += home_len - 1;
+              malloc_dirname = !use_alloca;
+
+              if (__glibc_unlikely (malloc_home_dir))
+                free (home_dir);
+            }
+          dirname_modified = 1;
+        }
       else
-	{
-	  char *end_name = strchr (dirname, '/');
-	  const char *user_name;
-	  const char *home_dir;
-	  char *unescape = NULL;
+        {
+#ifndef WINDOWS32
+          /* Recognize ~user as a shorthand for the specified user's home
+             directory.  */
+          char *end_name = strchr (dirname, '/');
+          char *user_name;
+          int malloc_user_name = 0;
+          char *unescape = NULL;
 
-	  if (!(flags & GLOB_NOESCAPE))
-	    {
-	      if (end_name == NULL)
-		{
-		  unescape = strchr (dirname, '\\');
-		  if (unescape)
-		    end_name = strchr (unescape, '\0');
-		}
-	      else
-		unescape = memchr (dirname, '\\', end_name - dirname);
-	    }
-	  if (end_name == NULL)
-	    user_name = dirname + 1;
-	  else
-	    {
-	      char *newp;
-	      newp = (char *) __alloca (end_name - dirname);
-	      if (unescape != NULL)
-		{
-		  char *p = mempcpy (newp, dirname + 1,
-				     unescape - dirname - 1);
-		  char *q = unescape;
-		  while (*q != '\0')
-		    {
-		      if (*q == '\\')
-			{
-			  if (q[1] == '\0')
-			    {
-			      /* "~fo\\o\\" unescape to user_name "foo\\",
-				 but "~fo\\o\\/" unescape to user_name
-				 "foo".  */
-			      if (filename == NULL)
-				*p++ = '\\';
-			      break;
-			    }
-			  ++q;
-			}
-		      *p++ = *q++;
-		    }
-		  *p = '\0';
-		}
-	      else
-		*((char *) mempcpy (newp, dirname + 1, end_name - dirname))
-		  = '\0';
-	      user_name = newp;
-	    }
+          if (!(flags & GLOB_NOESCAPE))
+            {
+              if (end_name == NULL)
+                {
+                  unescape = strchr (dirname, '\\');
+                  if (unescape)
+                    end_name = strchr (unescape, '\0');
+                }
+              else
+                unescape = memchr (dirname, '\\', end_name - dirname);
+            }
+          if (end_name == NULL)
+            user_name = dirname + 1;
+          else
+            {
+              char *newp;
+              if (glob_use_alloca (alloca_used, end_name - dirname))
+                newp = alloca_account (end_name - dirname, alloca_used);
+              else
+                {
+                  newp = malloc (end_name - dirname);
+                  if (newp == NULL)
+                    {
+                      retval = GLOB_NOSPACE;
+                      goto out;
+                    }
+                  malloc_user_name = 1;
+                }
+              if (unescape != NULL)
+                {
+                  char *p = mempcpy (newp, dirname + 1,
+                                     unescape - dirname - 1);
+                  char *q = unescape;
+                  while (*q != '\0')
+                    {
+                      if (*q == '\\')
+                        {
+                          if (q[1] == '\0')
+                            {
+                              /* "~fo\\o\\" unescape to user_name "foo\\",
+                                 but "~fo\\o\\/" unescape to user_name
+                                 "foo".  */
+                              if (filename == NULL)
+                                *p++ = '\\';
+                              break;
+                            }
+                          ++q;
+                        }
+                      *p++ = *q++;
+                    }
+                  *p = '\0';
+                }
+              else
+                *((char *) mempcpy (newp, dirname + 1, end_name - dirname))
+                  = '\0';
+              user_name = newp;
+            }
 
-	  /* Look up specific user's home directory.  */
-	  {
-	    struct passwd *p;
+          /* Look up specific user's home directory.  */
+          {
+            struct passwd *p;
+            struct scratch_buffer pwtmpbuf;
+            scratch_buffer_init (&pwtmpbuf);
+
 #  if defined HAVE_GETPWNAM_R || defined _LIBC
-	    long int buflen = GETPW_R_SIZE_MAX ();
-	    char *pwtmpbuf;
-	    struct passwd pwbuf;
-	    int save = errno;
+            struct passwd pwbuf;
 
-#   ifndef _LIBC
-	    if (buflen == -1)
-	      /* `sysconf' does not support _SC_GETPW_R_SIZE_MAX.  Try a
-		 moderate value.  */
-	      buflen = 1024;
-#   endif
-	    pwtmpbuf = (char *) __alloca (buflen);
-
-	    while (getpwnam_r (user_name, &pwbuf, pwtmpbuf, buflen, &p) != 0)
-	      {
-		if (errno != ERANGE)
-		  {
-		    p = NULL;
-		    break;
-		  }
-#   ifdef _LIBC
-		pwtmpbuf = extend_alloca (pwtmpbuf, buflen, 2 * buflen);
-#   else
-		buflen *= 2;
-		pwtmpbuf = __alloca (buflen);
-#   endif
-		__set_errno (save);
-	      }
+            while (getpwnam_r (user_name, &pwbuf,
+                               pwtmpbuf.data, pwtmpbuf.length, &p)
+                   == ERANGE)
+              {
+                if (!scratch_buffer_grow (&pwtmpbuf))
+                  {
+                    retval = GLOB_NOSPACE;
+                    goto out;
+                  }
+              }
 #  else
-	    p = getpwnam (user_name);
+            p = getpwnam (user_name);
 #  endif
-	    if (p != NULL)
-	      home_dir = p->pw_dir;
-	    else
-	      home_dir = NULL;
-	  }
-	  /* If we found a home directory use this.  */
-	  if (home_dir != NULL)
-	    {
-	      char *newp;
-	      size_t home_len = strlen (home_dir);
-	      size_t rest_len = end_name == NULL ? 0 : strlen (end_name);
-	      newp = (char *) __alloca (home_len + rest_len + 1);
-	      *((char *) mempcpy (mempcpy (newp, home_dir, home_len),
-				  end_name, rest_len)) = '\0';
-	      dirname = newp;
-	      dirlen = home_len + rest_len;
-	      dirname_modified = 1;
-	    }
-	  else
-	    if (flags & GLOB_TILDE_CHECK)
-	      /* We have to regard it as an error if we cannot find the
-		 home directory.  */
-	      return GLOB_NOMATCH;
-	}
-# endif	/* Not Amiga && not WINDOWS32.  */
+
+            if (__glibc_unlikely (malloc_user_name))
+              free (user_name);
+
+            /* If we found a home directory use this.  */
+            if (p != NULL)
+              {
+                size_t home_len = strlen (p->pw_dir);
+                size_t rest_len = end_name == NULL ? 0 : strlen (end_name);
+                /* dirname contains end_name; we can't free it now.  */
+                char *prev_dirname =
+                  (__glibc_unlikely (malloc_dirname) ? dirname : NULL);
+                char *d;
+
+                malloc_dirname = 0;
+
+                if (glob_use_alloca (alloca_used, home_len + rest_len + 1))
+                  dirname = alloca_account (home_len + rest_len + 1,
+                                            alloca_used);
+                else
+                  {
+                    dirname = malloc (home_len + rest_len + 1);
+                    if (dirname == NULL)
+                      {
+                        free (prev_dirname);
+                        scratch_buffer_free (&pwtmpbuf);
+                        retval = GLOB_NOSPACE;
+                        goto out;
+                      }
+                    malloc_dirname = 1;
+                  }
+                d = mempcpy (dirname, p->pw_dir, home_len);
+                if (end_name != NULL)
+                  d = mempcpy (d, end_name, rest_len);
+                *d = '\0';
+
+                free (prev_dirname);
+
+                dirlen = home_len + rest_len;
+                dirname_modified = 1;
+              }
+            else
+              {
+                if (flags & GLOB_TILDE_CHECK)
+                  {
+                    /* We have to regard it as an error if we cannot find the
+                       home directory.  */
+                    retval = GLOB_NOMATCH;
+                    goto out;
+                  }
+              }
+            scratch_buffer_free (&pwtmpbuf);
+          }
+#else /* WINDOWS32 */
+          /* On native Windows, access to a user's home directory
+             (via GetUserProfileDirectory) or to a user's environment
+             variables (via ExpandEnvironmentStringsForUser) requires
+             the credentials of the user.  Therefore we cannot support
+             the ~user syntax on this platform.
+             Handling ~user specially (and treat it like plain ~) if
+             user is getenv ("USERNAME") would not be a good idea,
+             since it would make people think that ~user is supported
+             in general.  */
+          if (flags & GLOB_TILDE_CHECK)
+            {
+              retval = GLOB_NOMATCH;
+              goto out;
+            }
+#endif /* WINDOWS32 */
+        }
     }
-#endif	/* Not VMS.  */
 
   /* Now test whether we looked for "~" or "~NAME".  In this case we
      can give the answer now.  */
   if (filename == NULL)
     {
-      struct stat st;
-      struct_stat64 st64;
+        size_t newcount = pglob->gl_pathc + pglob->gl_offs;
+        char **new_gl_pathv;
 
-      /* Return the directory if we don't check for error or if it exists.  */
-      if ((flags & GLOB_NOCHECK)
-	  || (((__builtin_expect (flags & GLOB_ALTDIRFUNC, 0))
-	       ? ((*pglob->gl_stat) (dirname, &st) == 0
-		  && S_ISDIR (st.st_mode))
-	       : (__stat64 (dirname, &st64) == 0 && S_ISDIR (st64.st_mode)))))
-	{
-	  int newcount = pglob->gl_pathc + pglob->gl_offs;
-	  char **new_gl_pathv;
+        if (newcount > SIZE_MAX / sizeof (char *) - 2)
+          {
+          nospace:
+            free (pglob->gl_pathv);
+            pglob->gl_pathv = NULL;
+            pglob->gl_pathc = 0;
+            retval = GLOB_NOSPACE;
+            goto out;
+          }
 
-	  new_gl_pathv
-	    = (char **) realloc (pglob->gl_pathv,
-				 (newcount + 1 + 1) * sizeof (char *));
-	  if (new_gl_pathv == NULL)
-	    {
-	    nospace:
-	      free (pglob->gl_pathv);
-	      pglob->gl_pathv = NULL;
-	      pglob->gl_pathc = 0;
-	      return GLOB_NOSPACE;
-	    }
-	  pglob->gl_pathv = new_gl_pathv;
+        new_gl_pathv = realloc (pglob->gl_pathv,
+                                (newcount + 2) * sizeof (char *));
+        if (new_gl_pathv == NULL)
+          goto nospace;
+        pglob->gl_pathv = new_gl_pathv;
 
-	  if (flags & GLOB_MARK)
-	    {
-	      char *p;
-	      pglob->gl_pathv[newcount] = malloc (dirlen + 2);
-	      if (pglob->gl_pathv[newcount] == NULL)
-		goto nospace;
-	      p = mempcpy (pglob->gl_pathv[newcount], dirname, dirlen);
-	      p[0] = '/';
-	      p[1] = '\0';
-	    }
-	  else
-	    {
-	      pglob->gl_pathv[newcount] = strdup (dirname);
-	      if (pglob->gl_pathv[newcount] == NULL)
-		goto nospace;
-	    }
-	  pglob->gl_pathv[++newcount] = NULL;
-	  ++pglob->gl_pathc;
-	  pglob->gl_flags = flags;
+        if (flags & GLOB_MARK && is_dir (dirname, flags, pglob))
+          {
+            char *p;
+            pglob->gl_pathv[newcount] = malloc (dirlen + 2);
+            if (pglob->gl_pathv[newcount] == NULL)
+              goto nospace;
+            p = mempcpy (pglob->gl_pathv[newcount], dirname, dirlen);
+            p[0] = '/';
+            p[1] = '\0';
+            if (__glibc_unlikely (malloc_dirname))
+              free (dirname);
+          }
+        else
+          {
+            if (__glibc_unlikely (malloc_dirname))
+              pglob->gl_pathv[newcount] = dirname;
+            else
+              {
+                pglob->gl_pathv[newcount] = strdup (dirname);
+                if (pglob->gl_pathv[newcount] == NULL)
+                  goto nospace;
+              }
+          }
+        pglob->gl_pathv[++newcount] = NULL;
+        ++pglob->gl_pathc;
+        pglob->gl_flags = flags;
 
-	  return 0;
-	}
-
-      /* Not found.  */
-      return GLOB_NOMATCH;
+        return 0;
     }
 
   meta = __glob_pattern_type (dirname, !(flags & GLOB_NOESCAPE));
@@ -894,261 +1021,239 @@ glob (pattern, flags, errfunc, pglob)
      [ which we handle the same, using fnmatch.  Broken unterminated
      pattern bracket expressions ought to be rare enough that it is
      not worth special casing them, fnmatch will do the right thing.  */
-  if (meta & 5)
+  if (meta & (GLOBPAT_SPECIAL | GLOBPAT_BRACKET))
     {
       /* The directory name contains metacharacters, so we
-	 have to glob for the directory, and then glob for
-	 the pattern in each directory found.  */
+         have to glob for the directory, and then glob for
+         the pattern in each directory found.  */
       size_t i;
 
       if (!(flags & GLOB_NOESCAPE) && dirlen > 0 && dirname[dirlen - 1] == '\\')
-	{
-	  /* "foo\\/bar".  Remove the final backslash from dirname
-	     if it has not been quoted.  */
-	  char *p = (char *) &dirname[dirlen - 1];
+        {
+          /* "foo\\/bar".  Remove the final backslash from dirname
+             if it has not been quoted.  */
+          char *p = (char *) &dirname[dirlen - 1];
 
-	  while (p > dirname && p[-1] == '\\') --p;
-	  if ((&dirname[dirlen] - p) & 1)
-	    *(char *) &dirname[--dirlen] = '\0';
-	}
+          while (p > dirname && p[-1] == '\\') --p;
+          if ((&dirname[dirlen] - p) & 1)
+            *(char *) &dirname[--dirlen] = '\0';
+        }
 
-      if (__builtin_expect ((flags & GLOB_ALTDIRFUNC) != 0, 0))
-	{
-	  /* Use the alternative access functions also in the recursive
-	     call.  */
-	  dirs.gl_opendir = pglob->gl_opendir;
-	  dirs.gl_readdir = pglob->gl_readdir;
-	  dirs.gl_closedir = pglob->gl_closedir;
-	  dirs.gl_stat = pglob->gl_stat;
-	  dirs.gl_lstat = pglob->gl_lstat;
-	}
+      if (__glibc_unlikely ((flags & GLOB_ALTDIRFUNC) != 0))
+        {
+          /* Use the alternative access functions also in the recursive
+             call.  */
+          dirs.gl_opendir = pglob->gl_opendir;
+          dirs.gl_readdir = pglob->gl_readdir;
+          dirs.gl_closedir = pglob->gl_closedir;
+          dirs.gl_stat = pglob->gl_stat;
+          dirs.gl_lstat = pglob->gl_lstat;
+        }
 
-      status = glob (dirname,
-		     ((flags & (GLOB_ERR | GLOB_NOESCAPE
-				| GLOB_ALTDIRFUNC))
-		      | GLOB_NOSORT | GLOB_ONLYDIR),
-		     errfunc, &dirs);
+      status = __glob (dirname,
+                       ((flags & (GLOB_ERR | GLOB_NOESCAPE | GLOB_ALTDIRFUNC))
+                        | GLOB_NOSORT | GLOB_ONLYDIR),
+                       errfunc, &dirs);
       if (status != 0)
-	{
-	  if ((flags & GLOB_NOCHECK) == 0 || status != GLOB_NOMATCH)
-	    return status;
-	  goto no_matches;
-	}
+        {
+          if ((flags & GLOB_NOCHECK) == 0 || status != GLOB_NOMATCH)
+            {
+              retval = status;
+              goto out;
+            }
+          goto no_matches;
+        }
 
       /* We have successfully globbed the preceding directory name.
-	 For each name we found, call glob_in_dir on it and FILENAME,
-	 appending the results to PGLOB.  */
+         For each name we found, call glob_in_dir on it and FILENAME,
+         appending the results to PGLOB.  */
       for (i = 0; i < dirs.gl_pathc; ++i)
-	{
-	  int old_pathc;
+        {
+          size_t old_pathc;
 
-#ifdef	SHELL
-	  {
-	    /* Make globbing interruptible in the bash shell. */
-	    extern int interrupt_state;
+          old_pathc = pglob->gl_pathc;
+          status = glob_in_dir (filename, dirs.gl_pathv[i],
+                                ((flags | GLOB_APPEND)
+                                 & ~(GLOB_NOCHECK | GLOB_NOMAGIC)),
+                                errfunc, pglob, alloca_used);
+          if (status == GLOB_NOMATCH)
+            /* No matches in this directory.  Try the next.  */
+            continue;
 
-	    if (interrupt_state)
-	      {
-		globfree (&dirs);
-		return GLOB_ABORTED;
-	      }
-	  }
-#endif /* SHELL.  */
+          if (status != 0)
+            {
+              globfree (&dirs);
+              globfree (pglob);
+              pglob->gl_pathc = 0;
+              retval = status;
+              goto out;
+            }
 
-	  old_pathc = pglob->gl_pathc;
-	  status = glob_in_dir (filename, dirs.gl_pathv[i],
-				((flags | GLOB_APPEND)
-				 & ~(GLOB_NOCHECK | GLOB_NOMAGIC)),
-				errfunc, pglob);
-	  if (status == GLOB_NOMATCH)
-	    /* No matches in this directory.  Try the next.  */
-	    continue;
-
-	  if (status != 0)
-	    {
-	      globfree (&dirs);
-	      globfree (pglob);
-	      pglob->gl_pathc = 0;
-	      return status;
-	    }
-
-	  /* Stick the directory on the front of each name.  */
-	  if (prefix_array (dirs.gl_pathv[i],
-			    &pglob->gl_pathv[old_pathc + pglob->gl_offs],
-			    pglob->gl_pathc - old_pathc))
-	    {
-	      globfree (&dirs);
-	      globfree (pglob);
-	      pglob->gl_pathc = 0;
-	      return GLOB_NOSPACE;
-	    }
-	}
+          /* Stick the directory on the front of each name.  */
+          if (prefix_array (dirs.gl_pathv[i],
+                            &pglob->gl_pathv[old_pathc + pglob->gl_offs],
+                            pglob->gl_pathc - old_pathc))
+            {
+              globfree (&dirs);
+              globfree (pglob);
+              pglob->gl_pathc = 0;
+              retval = GLOB_NOSPACE;
+              goto out;
+            }
+        }
 
       flags |= GLOB_MAGCHAR;
 
-      /* We have ignored the GLOB_NOCHECK flag in the `glob_in_dir' calls.
-	 But if we have not found any matching entry and the GLOB_NOCHECK
-	 flag was set we must return the input pattern itself.  */
+      /* We have ignored the GLOB_NOCHECK flag in the 'glob_in_dir' calls.
+         But if we have not found any matching entry and the GLOB_NOCHECK
+         flag was set we must return the input pattern itself.  */
       if (pglob->gl_pathc + pglob->gl_offs == oldcount)
-	{
-	no_matches:
-	  /* No matches.  */
-	  if (flags & GLOB_NOCHECK)
-	    {
-	      int newcount = pglob->gl_pathc + pglob->gl_offs;
-	      char **new_gl_pathv;
+        {
+        no_matches:
+          /* No matches.  */
+          if (flags & GLOB_NOCHECK)
+            {
+              size_t newcount = pglob->gl_pathc + pglob->gl_offs;
+              char **new_gl_pathv;
 
-	      new_gl_pathv = (char **) realloc (pglob->gl_pathv,
-						(newcount + 2)
-						* sizeof (char *));
-	      if (new_gl_pathv == NULL)
-		{
-		  globfree (&dirs);
-		  return GLOB_NOSPACE;
-		}
-	      pglob->gl_pathv = new_gl_pathv;
+              if (newcount > SIZE_MAX / sizeof (char *) - 2)
+                {
+                nospace2:
+                  globfree (&dirs);
+                  retval = GLOB_NOSPACE;
+                  goto out;
+                }
 
-	      pglob->gl_pathv[newcount] = strdup (pattern); /* SB2 */
-	      if (pglob->gl_pathv[newcount] == NULL)
-		{
-		  globfree (&dirs);
-		  globfree (pglob);
-		  pglob->gl_pathc = 0;
-		  return GLOB_NOSPACE;
-		}
+              new_gl_pathv = realloc (pglob->gl_pathv,
+                                      (newcount + 2) * sizeof (char *));
+              if (new_gl_pathv == NULL)
+                goto nospace2;
+              pglob->gl_pathv = new_gl_pathv;
 
-	      ++pglob->gl_pathc;
-	      ++newcount;
+              pglob->gl_pathv[newcount] = strdup (pattern);
+              if (pglob->gl_pathv[newcount] == NULL)
+                {
+                  globfree (&dirs);
+                  globfree (pglob);
+                  pglob->gl_pathc = 0;
+                  retval = GLOB_NOSPACE;
+                  goto out;
+                }
 
-	      pglob->gl_pathv[newcount] = NULL;
-	      pglob->gl_flags = flags;
-	    }
-	  else
-	    {
-	      globfree (&dirs);
-	      return GLOB_NOMATCH;
-	    }
-	}
+              ++pglob->gl_pathc;
+              ++newcount;
+
+              pglob->gl_pathv[newcount] = NULL;
+              pglob->gl_flags = flags;
+            }
+          else
+            {
+              globfree (&dirs);
+              retval = GLOB_NOMATCH;
+              goto out;
+            }
+        }
 
       globfree (&dirs);
     }
   else
     {
-      int old_pathc = pglob->gl_pathc;
+      size_t old_pathc = pglob->gl_pathc;
       int orig_flags = flags;
 
-      if (meta & 2)
-	{
-	  char *p = strchr (dirname, '\\'), *q;
-	  /* We need to unescape the dirname string.  It is certainly
-	     allocated by alloca, as otherwise filename would be NULL
-	     or dirname wouldn't contain backslashes.  */
-	  q = p;
-	  do
-	    {
-	      if (*p == '\\')
-		{
-		  *q = *++p;
-		  --dirlen;
-		}
-	      else
-		*q = *p;
-	      ++q;
-	    }
-	  while (*p++ != '\0');
-	  dirname_modified = 1;
-	}
+      if (meta & GLOBPAT_BACKSLASH)
+        {
+          char *p = strchr (dirname, '\\'), *q;
+          /* We need to unescape the dirname string.  It is certainly
+             allocated by alloca, as otherwise filename would be NULL
+             or dirname wouldn't contain backslashes.  */
+          q = p;
+          do
+            {
+              if (*p == '\\')
+                {
+                  *q = *++p;
+                  --dirlen;
+                }
+              else
+                *q = *p;
+              ++q;
+            }
+          while (*p++ != '\0');
+          dirname_modified = 1;
+        }
       if (dirname_modified)
-	flags &= ~(GLOB_NOCHECK | GLOB_NOMAGIC);
-      status = glob_in_dir (filename, dirname, flags, errfunc, pglob);
+        flags &= ~(GLOB_NOCHECK | GLOB_NOMAGIC);
+      status = glob_in_dir (filename, dirname, flags, errfunc, pglob,
+                            alloca_used);
       if (status != 0)
-	{
-	  if (status == GLOB_NOMATCH && flags != orig_flags
-	      && pglob->gl_pathc + pglob->gl_offs == oldcount)
-	    {
-	      /* Make sure globfree (&dirs); is a nop.  */
-	      dirs.gl_pathv = NULL;
-	      flags = orig_flags;
-	      goto no_matches;
-	    }
-	  return status;
-	}
+        {
+          if (status == GLOB_NOMATCH && flags != orig_flags
+              && pglob->gl_pathc + pglob->gl_offs == oldcount)
+            {
+              /* Make sure globfree (&dirs); is a nop.  */
+              dirs.gl_pathv = NULL;
+              flags = orig_flags;
+              goto no_matches;
+            }
+          retval = status;
+          goto out;
+        }
 
       if (dirlen > 0)
-	{
-	  /* Stick the directory on the front of each name.  */
-	  if (prefix_array (dirname,
-			    &pglob->gl_pathv[old_pathc + pglob->gl_offs],
-			    pglob->gl_pathc - old_pathc))
-	    {
-	      globfree (pglob);
-	      pglob->gl_pathc = 0;
-	      return GLOB_NOSPACE;
-	    }
-	}
+        {
+          /* Stick the directory on the front of each name.  */
+          if (prefix_array (dirname,
+                            &pglob->gl_pathv[old_pathc + pglob->gl_offs],
+                            pglob->gl_pathc - old_pathc))
+            {
+              globfree (pglob);
+              pglob->gl_pathc = 0;
+              retval = GLOB_NOSPACE;
+              goto out;
+            }
+        }
     }
 
   if (flags & GLOB_MARK)
     {
       /* Append slashes to directory names.  */
       size_t i;
-      struct stat st;
-      struct_stat64 st64;
 
       for (i = oldcount; i < pglob->gl_pathc + pglob->gl_offs; ++i)
-	if ((__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-	     ? ((*pglob->gl_stat) (pglob->gl_pathv[i], &st) == 0
-		&& S_ISDIR (st.st_mode))
-	     : (__stat64 (pglob->gl_pathv[i], &st64) == 0
-		&& S_ISDIR (st64.st_mode))))
-	  {
-	    size_t len = strlen (pglob->gl_pathv[i]) + 2;
-	    char *new = realloc (pglob->gl_pathv[i], len);
-	    if (new == NULL)
-	      {
-		globfree (pglob);
-		pglob->gl_pathc = 0;
-		return GLOB_NOSPACE;
-	      }
-	    strcpy (&new[len - 2], "/");
-	    pglob->gl_pathv[i] = new;
-	  }
+        if (is_dir (pglob->gl_pathv[i], flags, pglob))
+          {
+            size_t len = strlen (pglob->gl_pathv[i]) + 2;
+            char *new = realloc (pglob->gl_pathv[i], len);
+            if (new == NULL)
+              {
+                globfree (pglob);
+                pglob->gl_pathc = 0;
+                retval = GLOB_NOSPACE;
+                goto out;
+              }
+            strcpy (&new[len - 2], "/");
+            pglob->gl_pathv[i] = new;
+          }
     }
 
   if (!(flags & GLOB_NOSORT))
     {
       /* Sort the vector.  */
       qsort (&pglob->gl_pathv[oldcount],
-	     pglob->gl_pathc + pglob->gl_offs - oldcount,
-	     sizeof (char *), collated_compare);
+             pglob->gl_pathc + pglob->gl_offs - oldcount,
+             sizeof (char *), collated_compare);
     }
 
-  return 0;
+ out:
+  if (__glibc_unlikely (malloc_dirname))
+    free (dirname);
+
+  return retval;
 }
-#if defined _LIBC && !defined glob
-libc_hidden_def (glob)
-#endif
-
-
-#if !defined _LIBC || !defined GLOB_ONLY_P
-
-/* Free storage allocated in PGLOB by a previous `glob' call.  */
-void
-globfree (pglob)
-     register glob_t *pglob;
-{
-  if (pglob->gl_pathv != NULL)
-    {
-      size_t i;
-      for (i = 0; i < pglob->gl_pathc; ++i)
-	if (pglob->gl_pathv[pglob->gl_offs + i] != NULL)
-	  free (pglob->gl_pathv[pglob->gl_offs + i]);
-      free (pglob->gl_pathv);
-      pglob->gl_pathv = NULL;
-    }
-}
-#if defined _LIBC && !defined globfree
-libc_hidden_def (globfree)
+#if defined _LIBC && !defined __glob
+versioned_symbol (libc, __glob, glob, GLIBC_2_27);
+libc_hidden_ver (__glob, glob)
 #endif
 
 
@@ -1156,8 +1261,8 @@ libc_hidden_def (globfree)
 static int
 collated_compare (const void *a, const void *b)
 {
-  const char *const s1 = *(const char *const * const) a;
-  const char *const s2 = *(const char *const * const) b;
+  char *const *ps1 = a; char *s1 = *ps1;
+  char *const *ps2 = b; char *s2 = *ps2;
 
   if (s1 == s2)
     return 0;
@@ -1176,49 +1281,45 @@ collated_compare (const void *a, const void *b)
 static int
 prefix_array (const char *dirname, char **array, size_t n)
 {
-  register size_t i;
+  size_t i;
   size_t dirlen = strlen (dirname);
-#if defined __MSDOS__ || defined WINDOWS32
-  int sep_char = '/';
-# define DIRSEP_CHAR sep_char
-#else
-# define DIRSEP_CHAR '/'
-#endif
+  char dirsep_char = '/';
 
   if (dirlen == 1 && dirname[0] == '/')
     /* DIRNAME is just "/", so normal prepending would get us "//foo".
        We want "/foo" instead, so don't prepend any chars from DIRNAME.  */
     dirlen = 0;
+
 #if defined __MSDOS__ || defined WINDOWS32
-  else if (dirlen > 1)
+  if (dirlen > 1)
     {
       if (dirname[dirlen - 1] == '/' && dirname[dirlen - 2] == ':')
-	/* DIRNAME is "d:/".  Don't prepend the slash from DIRNAME.  */
-	--dirlen;
+        /* DIRNAME is "d:/".  Don't prepend the slash from DIRNAME.  */
+        --dirlen;
       else if (dirname[dirlen - 1] == ':')
-	{
-	  /* DIRNAME is "d:".  Use `:' instead of `/'.  */
-	  --dirlen;
-	  sep_char = ':';
-	}
+        {
+          /* DIRNAME is "d:".  Use ':' instead of '/'.  */
+          --dirlen;
+          dirsep_char = ':';
+        }
     }
 #endif
 
   for (i = 0; i < n; ++i)
     {
       size_t eltlen = strlen (array[i]) + 1;
-      char *new = (char *) malloc (dirlen + 1 + eltlen);
+      char *new = malloc (dirlen + 1 + eltlen);
       if (new == NULL)
-	{
-	  while (i > 0)
-	    free (array[--i]);
-	  return 1;
-	}
+        {
+          while (i > 0)
+            free (array[--i]);
+          return 1;
+        }
 
       {
-	char *endp = mempcpy (new, dirname, dirlen);
-	*endp++ = DIRSEP_CHAR;
-	mempcpy (endp, array[i], eltlen);
+        char *endp = mempcpy (new, dirname, dirlen);
+        *endp++ = dirsep_char;
+        mempcpy (endp, array[i], eltlen);
       }
       free (array[i]);
       array[i] = new;
@@ -1227,373 +1328,275 @@ prefix_array (const char *dirname, char **array, size_t n)
   return 0;
 }
 
-
-/* We must not compile this function twice.  */
-#if !defined NO_GLOB_PATTERN_P /* SB2 */
-#if !defined _LIBC || !defined NO_GLOB_PATTERN_P
-int
-__glob_pattern_type (pattern, quote)
-     const char *pattern;
-     int quote;
-{
-  register const char *p;
-  int ret = 0;
-
-  for (p = pattern; *p != '\0'; ++p)
-    switch (*p)
-      {
-      case '?':
-      case '*':
-	return 1;
-
-      case '\\':
-	if (quote)
-	  {
-	    if (p[1] != '\0')
-	      ++p;
-	    ret |= 2;
-	  }
-	break;
-
-      case '[':
-	ret |= 4;
-	break;
-
-      case ']':
-	if (ret & 4)
-	  return 1;
-	break;
-      }
-
-  return ret;
-}
-
-/* Return nonzero if PATTERN contains any metacharacters.
-   Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
-int
-__glob_pattern_p (pattern, quote)
-     const char *pattern;
-     int quote;
-{
-  return __glob_pattern_type (pattern, quote) == 1;
-}
-# ifdef _LIBC
-weak_alias (__glob_pattern_p, glob_pattern_p)
-# endif
-#endif
-#endif
-
-#endif /* !GLOB_ONLY_P */
-
-
-/* We put this in a separate function mainly to allow the memory
-   allocated with alloca to be recycled.  */
-#if !defined _LIBC || !defined GLOB_ONLY_P
-static int
-__attribute_noinline__
-link_exists2_p (const char *dir, size_t dirlen, const char *fname,
-	       glob_t *pglob
-# ifndef _LIBC
-		, int flags
-# endif
-		)
-{
-  size_t fnamelen = strlen (fname);
-  char *fullname = (char *) __alloca (dirlen + 1 + fnamelen + 1);
-  struct stat st;
-# ifndef _LIBC
-  struct_stat64 st64;
-# endif
-
-  mempcpy (mempcpy (mempcpy (fullname, dir, dirlen), "/", 1),
-	   fname, fnamelen + 1);
-
-# ifdef _LIBC
-  return (*pglob->gl_stat) (fullname, &st) == 0;
-# else
-  return ((__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-	   ? (*pglob->gl_stat) (fullname, &st)
-	   : __stat64 (fullname, &st64)) == 0);
-# endif
-}
-# ifdef _LIBC
-#  define link_exists_p(dfd, dirname, dirnamelen, fname, pglob, flags) \
-  (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)			      \
-   ? link_exists2_p (dirname, dirnamelen, fname, pglob)			      \
-   : ({ struct stat64 st64;						      \
-       __fxstatat64 (_STAT_VER, dfd, fname, &st64, 0) == 0; }))
-# else
-#  define link_exists_p(dfd, dirname, dirnamelen, fname, pglob, flags) \
-  link_exists2_p (dirname, dirnamelen, fname, pglob, flags)
-# endif
-#endif
-
-
-/* Like `glob', but PATTERN is a final pathname component,
+/* Like 'glob', but PATTERN is a final pathname component,
    and matches are searched for in DIRECTORY.
    The GLOB_NOSORT bit in FLAGS is ignored.  No sorting is ever done.
    The GLOB_APPEND flag is assumed to be set (always appends).  */
 static int
 glob_in_dir (const char *pattern, const char *directory, int flags,
-	     int (*errfunc) (const char *, int),
-	     glob_t *pglob)
+             int (*errfunc) (const char *, int),
+             glob_t *pglob, size_t alloca_used)
 {
   size_t dirlen = strlen (directory);
   void *stream = NULL;
-  struct globnames
-    {
-      struct globnames *next;
-      size_t count;
-      char *name[64];
-    };
-#define INITIAL_COUNT sizeof (init_names.name) / sizeof (init_names.name[0])
-  struct globnames init_names;
-  struct globnames *names = &init_names;
-  struct globnames *names_alloca = &init_names;
+  struct scratch_buffer s;
+  scratch_buffer_init (&s);
+# define GLOBNAMES_MEMBERS(nnames) \
+    struct globnames *next; size_t count; char *name[nnames];
+  struct globnames { GLOBNAMES_MEMBERS (FLEXIBLE_ARRAY_MEMBER) };
+  struct { GLOBNAMES_MEMBERS (64) } init_names_buf;
+  struct globnames *init_names = (struct globnames *) &init_names_buf;
+  struct globnames *names = init_names;
+  struct globnames *names_alloca = init_names;
   size_t nfound = 0;
-  size_t allocasize = sizeof (init_names);
   size_t cur = 0;
   int meta;
   int save;
+  int result;
 
-  init_names.next = NULL;
-  init_names.count = INITIAL_COUNT;
+  alloca_used += sizeof init_names_buf;
+
+  init_names->next = NULL;
+  init_names->count = ((sizeof init_names_buf
+                        - offsetof (struct globnames, name))
+                       / sizeof init_names->name[0]);
 
   meta = __glob_pattern_type (pattern, !(flags & GLOB_NOESCAPE));
-  if (meta == 0 && (flags & (GLOB_NOCHECK|GLOB_NOMAGIC)))
+  if (meta == GLOBPAT_NONE && (flags & (GLOB_NOCHECK|GLOB_NOMAGIC)))
     {
       /* We need not do any tests.  The PATTERN contains no meta
-	 characters and we must not return an error therefore the
-	 result will always contain exactly one name.  */
+         characters and we must not return an error therefore the
+         result will always contain exactly one name.  */
       flags |= GLOB_NOCHECK;
     }
-  else if (meta == 0)
+  else if (meta == GLOBPAT_NONE)
     {
-      /* Since we use the normal file functions we can also use stat()
-	 to verify the file is there.  */
-      struct stat st;
-      struct_stat64 st64;
       size_t patlen = strlen (pattern);
-      char *fullname = (char *) __alloca (dirlen + 1 + patlen + 1);
+      size_t fullsize;
+      bool alloca_fullname
+        = (! size_add_wrapv (dirlen + 1, patlen + 1, &fullsize)
+           && glob_use_alloca (alloca_used, fullsize));
+      char *fullname;
+      if (alloca_fullname)
+        fullname = alloca_account (fullsize, alloca_used);
+      else
+        {
+          fullname = malloc (fullsize);
+          if (fullname == NULL)
+            return GLOB_NOSPACE;
+        }
 
       mempcpy (mempcpy (mempcpy (fullname, directory, dirlen),
-			"/", 1),
-	       pattern, patlen + 1);
-      if ((__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-	   ? (*pglob->gl_stat) (fullname, &st)
-	   : __stat64 (fullname, &st64)) == 0)
-	/* We found this file to be existing.  Now tell the rest
-	   of the function to copy this name into the result.  */
-	flags |= GLOB_NOCHECK;
+                        "/", 1),
+               pattern, patlen + 1);
+      if (glob_lstat (pglob, flags, fullname) == 0
+          || errno == EOVERFLOW)
+        /* We found this file to be existing.  Now tell the rest
+           of the function to copy this name into the result.  */
+        flags |= GLOB_NOCHECK;
+
+      if (__glibc_unlikely (!alloca_fullname))
+        free (fullname);
     }
   else
     {
       stream = (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-		? (*pglob->gl_opendir) (directory)
-		: opendir (directory));
+                ? (*pglob->gl_opendir) (directory)
+                : opendir (directory));
       if (stream == NULL)
-	{
-	  if (errno != ENOTDIR
-	      && ((errfunc != NULL && (*errfunc) (directory, errno))
-		  || (flags & GLOB_ERR)))
-	    return GLOB_ABORTED;
-	}
+        {
+          if (errno != ENOTDIR
+              && ((errfunc != NULL && (*errfunc) (directory, errno))
+                  || (flags & GLOB_ERR)))
+            return GLOB_ABORTED;
+        }
       else
-	{
-#ifdef _LIBC
-	  int dfd = (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-		     ? -1 : dirfd ((DIR *) stream));
-#endif
-	  int fnm_flags = ((!(flags & GLOB_PERIOD) ? FNM_PERIOD : 0)
-			   | ((flags & GLOB_NOESCAPE) ? FNM_NOESCAPE : 0)
-#if defined _AMIGA || defined VMS
-			   | FNM_CASEFOLD
-#endif
-			   );
-	  flags |= GLOB_MAGCHAR;
+        {
+          int dfd = dirfd (stream);
+          int fnm_flags = ((!(flags & GLOB_PERIOD) ? FNM_PERIOD : 0)
+                           | ((flags & GLOB_NOESCAPE) ? FNM_NOESCAPE : 0));
+          flags |= GLOB_MAGCHAR;
 
-	  while (1)
-	    {
-	      const char *name;
-	      size_t len;
-#if defined _LIBC && !defined COMPILE_GLOB64
-	      struct dirent64 *d;
-	      union
-		{
-		  struct dirent64 d64;
-		  char room [offsetof (struct dirent64, d_name[0])
-			     + NAME_MAX + 1];
-		}
-	      d64buf;
-
-	      if (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0))
-		{
-		  struct dirent *d32 = (*pglob->gl_readdir) (stream);
-		  if (d32 != NULL)
-		    {
-		      CONVERT_DIRENT_DIRENT64 (&d64buf.d64, d32);
-		      d = &d64buf.d64;
-		    }
-		  else
-		    d = NULL;
-		}
-	      else
-		d = __readdir64 (stream);
+          while (1)
+            {
+              struct readdir_result d;
+              {
+                if (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0))
+                  d = convert_dirent (GL_READDIR (pglob, stream));
+                else
+                  {
+#ifdef COMPILE_GLOB64
+                    d = convert_dirent (__readdir (stream));
 #else
-	      struct dirent *d = (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0)
-				  ? ((struct dirent *)
-				     (*pglob->gl_readdir) (stream))
-				  : __readdir (stream));
+                    d = convert_dirent64 (__readdir64 (stream));
 #endif
-	      if (d == NULL)
-		break;
-	      if (! REAL_DIR_ENTRY (d))
-		continue;
+                  }
+              }
+              if (d.name == NULL)
+                break;
 
-	      /* If we shall match only directories use the information
-		 provided by the dirent call if possible.  */
-	      if ((flags & GLOB_ONLYDIR) && !DIRENT_MIGHT_BE_DIR (d))
-		continue;
+              /* If we shall match only directories use the information
+                 provided by the dirent call if possible.  */
+              if (flags & GLOB_ONLYDIR)
+                switch (readdir_result_type (d))
+                  {
+                  default: continue;
+                  case DT_DIR: break;
+                  case DT_LNK: case DT_UNKNOWN:
+                    /* The filesystem was too lazy to give us a hint,
+                       so we have to do it the hard way.  */
+                    if (__glibc_unlikely (dfd < 0 || flags & GLOB_ALTDIRFUNC))
+                      {
+                        size_t namelen = strlen (d.name);
+                        size_t need = dirlen + 1 + namelen + 1;
+                        if (s.length < need
+                            && !scratch_buffer_set_array_size (&s, need, 1))
+                          goto memory_error;
+                        char *p = mempcpy (s.data, directory, dirlen);
+                        *p = '/';
+                        p += p[-1] != '/';
+                        memcpy (p, d.name, namelen + 1);
+                        if (! is_dir (s.data, flags, pglob))
+                          continue;
+                      }
+                    else
+                      {
+                        struct_stat64 st64;
+                        if (! (GLOB_FSTATAT64 (dfd, d.name, &st64, 0) == 0
+                               && S_ISDIR (st64.st_mode)))
+                          continue;
+                      }
+                  }
 
-	      name = d->d_name;
-
-	      if (fnmatch (pattern, name, fnm_flags) == 0)
-		{
-		  /* If the file we found is a symlink we have to
-		     make sure the target file exists.  */
-		  if (!DIRENT_MIGHT_BE_SYMLINK (d)
-		      || link_exists_p (dfd, directory, dirlen, name, pglob,
-					flags))
-		    {
-		      if (cur == names->count)
-			{
-			  struct globnames *newnames;
-			  size_t count = names->count * 2;
-			  size_t size = (sizeof (struct globnames)
-					 + ((count - INITIAL_COUNT)
-					    * sizeof (char *)));
-			  allocasize += size;
-			  if (__libc_use_alloca (allocasize))
-			    newnames = names_alloca = __alloca (size);
-			  else if ((newnames = malloc (size))
-				   == NULL)
-			    goto memory_error;
-			  newnames->count = count;
-			  newnames->next = names;
-			  names = newnames;
-			  cur = 0;
-			}
-		      len = NAMLEN (d);
-		      names->name[cur] = (char *) malloc (len + 1);
-		      if (names->name[cur] == NULL)
-			goto memory_error;
-		      *((char *) mempcpy (names->name[cur++], name, len))
-			= '\0';
-		      ++nfound;
-		    }
-		}
-	    }
-	}
+              if (fnmatch (pattern, d.name, fnm_flags) == 0)
+                {
+                  if (cur == names->count)
+                    {
+                      struct globnames *newnames;
+                      size_t count = names->count * 2;
+                      size_t nameoff = offsetof (struct globnames, name);
+                      size_t size = FLEXSIZEOF (struct globnames, name,
+                                                count * sizeof (char *));
+                      if ((SIZE_MAX - nameoff) / 2 / sizeof (char *)
+                          < names->count)
+                        goto memory_error;
+                      if (glob_use_alloca (alloca_used, size))
+                        newnames = names_alloca
+                          = alloca_account (size, alloca_used);
+                      else if ((newnames = malloc (size))
+                               == NULL)
+                        goto memory_error;
+                      newnames->count = count;
+                      newnames->next = names;
+                      names = newnames;
+                      cur = 0;
+                    }
+                  names->name[cur] = strdup (d.name);
+                  if (names->name[cur] == NULL)
+                    goto memory_error;
+                  ++cur;
+                  ++nfound;
+                  if (SIZE_MAX - pglob->gl_offs <= nfound)
+                    goto memory_error;
+                }
+            }
+        }
     }
 
   if (nfound == 0 && (flags & GLOB_NOCHECK))
     {
       size_t len = strlen (pattern);
       nfound = 1;
-      names->name[cur] = (char *) malloc (len + 1);
+      names->name[cur] = malloc (len + 1);
       if (names->name[cur] == NULL)
-	goto memory_error;
+        goto memory_error;
       *((char *) mempcpy (names->name[cur++], pattern, len)) = '\0';
     }
 
-  int result = GLOB_NOMATCH;
+  result = GLOB_NOMATCH;
   if (nfound != 0)
     {
+      char **new_gl_pathv;
       result = 0;
 
-      char **new_gl_pathv;
+      if (SIZE_MAX / sizeof (char *) - pglob->gl_pathc
+          < pglob->gl_offs + nfound + 1)
+        goto memory_error;
+
       new_gl_pathv
-	= (char **) realloc (pglob->gl_pathv,
-			     (pglob->gl_pathc + pglob->gl_offs + nfound + 1)
-			     * sizeof (char *));
+        = realloc (pglob->gl_pathv,
+                   (pglob->gl_pathc + pglob->gl_offs + nfound + 1)
+                    * sizeof (char *));
+
       if (new_gl_pathv == NULL)
-	{
-	memory_error:
-	  while (1)
-	    {
-	      struct globnames *old = names;
-#if 0
-	      for (size_t i = 0; i < cur; ++i)
-#else
-	      size_t i;
-	      for (i = 0; i < cur; ++i)
-#endif
-		free (names->name[i]);
-	      names = names->next;
-	      /* NB: we will not leak memory here if we exit without
-		 freeing the current block assigned to OLD.  At least
-		 the very first block is always allocated on the stack
-		 and this is the block assigned to OLD here.  */
-	      if (names == NULL)
-		{
-		  assert (old == &init_names);
-		  break;
-		}
-	      cur = names->count;
-	      if (old == names_alloca)
-		names_alloca = names;
-	      else
-		free (old);
-	    }
-	  result = GLOB_NOSPACE;
-	}
+        {
+        memory_error:
+          while (1)
+            {
+              struct globnames *old = names;
+              for (size_t i = 0; i < cur; ++i)
+                free (names->name[i]);
+              names = names->next;
+              /* NB: we will not leak memory here if we exit without
+                 freeing the current block assigned to OLD.  At least
+                 the very first block is always allocated on the stack
+                 and this is the block assigned to OLD here.  */
+              if (names == NULL)
+                {
+                  assert (old == init_names);
+                  break;
+                }
+              cur = names->count;
+              if (old == names_alloca)
+                names_alloca = names;
+              else
+                free (old);
+            }
+          result = GLOB_NOSPACE;
+        }
       else
-	{
-	  while (1)
-	    {
-	      struct globnames *old = names;
-#if 0
-	      for (size_t i = 0; i < cur; ++i)
-#else
-	      size_t i;
-	      for (i = 0; i < cur; ++i)
-#endif
-		new_gl_pathv[pglob->gl_offs + pglob->gl_pathc++]
-		  = names->name[i];
-	      names = names->next;
-	      /* NB: we will not leak memory here if we exit without
-		 freeing the current block assigned to OLD.  At least
-		 the very first block is always allocated on the stack
-		 and this is the block assigned to OLD here.  */
-	      if (names == NULL)
-		{
-		  assert (old == &init_names);
-		  break;
-		}
-	      cur = names->count;
-	      if (old == names_alloca)
-		names_alloca = names;
-	      else
-		free (old);
-	    }
+        {
+          while (1)
+            {
+              struct globnames *old = names;
+              for (size_t i = 0; i < cur; ++i)
+                new_gl_pathv[pglob->gl_offs + pglob->gl_pathc++]
+                  = names->name[i];
+              names = names->next;
+              /* NB: we will not leak memory here if we exit without
+                 freeing the current block assigned to OLD.  At least
+                 the very first block is always allocated on the stack
+                 and this is the block assigned to OLD here.  */
+              if (names == NULL)
+                {
+                  assert (old == init_names);
+                  break;
+                }
+              cur = names->count;
+              if (old == names_alloca)
+                names_alloca = names;
+              else
+                free (old);
+            }
 
-	  pglob->gl_pathv = new_gl_pathv;
+          pglob->gl_pathv = new_gl_pathv;
 
-	  pglob->gl_pathv[pglob->gl_offs + pglob->gl_pathc] = NULL;
+          pglob->gl_pathv[pglob->gl_offs + pglob->gl_pathc] = NULL;
 
-	  pglob->gl_flags = flags;
-	}
+          pglob->gl_flags = flags;
+        }
     }
 
   if (stream != NULL)
     {
       save = errno;
-      if (__builtin_expect (flags & GLOB_ALTDIRFUNC, 0))
-	(*pglob->gl_closedir) (stream);
+      if (__glibc_unlikely (flags & GLOB_ALTDIRFUNC))
+        (*pglob->gl_closedir) (stream);
       else
-	closedir (stream);
+        closedir (stream);
       __set_errno (save);
     }
 
+  scratch_buffer_free (&s);
   return result;
 }

--- a/preload/glob64.c
+++ b/preload/glob64.c
@@ -1,11 +1,6 @@
-/* Copied from glibc-2.7 to Scratchbox 2,
- * from glibc's sysdep/gnu/glob64.c.
+/* Copied from glibc-2.42 to Scratchbox 2,
+ * from glibc's sysdeps/gnu/glob64.c.
 */
-
-#include <config.h>
-
-// Apple doesn't have 64bit dirent?
-#ifndef __APPLE__
 
 #include <dirent.h>
 #include <glob.h>
@@ -15,10 +10,8 @@
 #define __readdir(dirp) __readdir64 (dirp)
 
 #define glob_t glob64_t
-#if 0
-#define glob(pattern, flags, errfunc, pglob) \
-  glob64 (pattern, flags, errfunc, pglob)
-#endif
+// SB2 - defined in glob.c
+// #define __glob __glob64
 #define globfree(pglob) globfree64 (pglob)
 
 #undef stat
@@ -32,5 +25,6 @@
 
 #include "glob.c"
 
-#endif
-
+/* SB2
+ * libc_hidden_def (glob64)
+ */

--- a/preload/glob_internal.h
+++ b/preload/glob_internal.h
@@ -1,0 +1,70 @@
+/* Copied from glibc-2.42 to Scratchbox 2
+ *
+ * added from glibc's posix/glob_internal.h:
+*/
+
+/* Shared definition for glob and glob_pattern_p.
+   Copyright (C) 2025 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#ifndef GLOB_INTERNAL_H
+# define GLOB_INTERNAL_H
+
+enum
+{
+  GLOBPAT_NONE      = 0x0,
+  GLOBPAT_SPECIAL   = 0x1,
+  GLOBPAT_BACKSLASH = 0x2,
+  GLOBPAT_BRACKET   = 0x4
+};
+
+static inline int
+__glob_pattern_type (const char *pattern, int quote)
+{
+  const char *p;
+  int ret = GLOBPAT_NONE;
+
+  for (p = pattern; *p != '\0'; ++p)
+    switch (*p)
+      {
+      case '?':
+      case '*':
+        return GLOBPAT_SPECIAL;
+
+      case '\\':
+        if (quote)
+          {
+            if (p[1] != '\0')
+              ++p;
+            ret |= GLOBPAT_BACKSLASH;
+          }
+        break;
+
+      case '[':
+        ret |= GLOBPAT_BRACKET;
+        break;
+
+      case ']':
+        if (ret & 4)
+          return GLOBPAT_SPECIAL;
+        break;
+      }
+
+  return ret;
+}
+
+#endif /* GLOB_INTERNAL_H  */

--- a/preload/miscgates.c
+++ b/preload/miscgates.c
@@ -341,7 +341,7 @@ char *__realpath_chk_gate(
 
 
 /* "SB2_WRAP_GLOB" needs to be defined on systems where the C library
- * is not based on glibc (or not compatible with glob() from glibc 2.7)
+ * is not based on glibc (or not compatible with glob() from glibc 2.42)
 */
 #ifdef SB2_WRAP_GLOB
 static char *check_and_prepare_glob_pattern(

--- a/preload/scratch_buffer.h
+++ b/preload/scratch_buffer.h
@@ -1,0 +1,145 @@
+/* Copied from glibc-2.42 to Scratchbox 2
+ *
+ * added from glibc's include/scratch_buffer.h:
+*/
+
+/* Variable-sized buffer with on-stack default allocation.
+   Copyright (C) 2015-2025 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#ifndef _SCRATCH_BUFFER_H
+#define _SCRATCH_BUFFER_H
+
+/* Scratch buffers with a default stack allocation and fallback to
+   heap allocation.  It is expected that this function is used in this
+   way:
+
+     struct scratch_buffer tmpbuf;
+     scratch_buffer_init (&tmpbuf);
+
+     while (!function_that_uses_buffer (tmpbuf.data, tmpbuf.length))
+       if (!scratch_buffer_grow (&tmpbuf))
+	 return -1;
+
+     scratch_buffer_free (&tmpbuf);
+     return 0;
+
+   The allocation functions (scratch_buffer_grow,
+   scratch_buffer_grow_preserve, scratch_buffer_set_array_size) make
+   sure that the heap allocation, if any, is freed, so that the code
+   above does not have a memory leak.  The buffer still remains in a
+   state that can be deallocated using scratch_buffer_free, so a loop
+   like this is valid as well:
+
+     struct scratch_buffer tmpbuf;
+     scratch_buffer_init (&tmpbuf);
+
+     while (!function_that_uses_buffer (tmpbuf.data, tmpbuf.length))
+       if (!scratch_buffer_grow (&tmpbuf))
+	 break;
+
+     scratch_buffer_free (&tmpbuf);
+
+   scratch_buffer_grow and scratch_buffer_grow_preserve are guaranteed
+   to grow the buffer by at least 512 bytes.  This means that when
+   using the scratch buffer as a backing store for a non-character
+   array whose element size, in bytes, is 512 or smaller, the scratch
+   buffer only has to grow once to make room for at least one more
+   element.
+*/
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+/* SB2 */
+#ifndef libc_hidden_proto
+# define libc_hidden_proto(name, attrs...)
+#endif
+
+/* Scratch buffer.  Must be initialized with scratch_buffer_init
+   before its use.  */
+struct scratch_buffer {
+  void *data;    /* Pointer to the beginning of the scratch area.  */
+  size_t length; /* Allocated space at the data pointer, in bytes.  */
+  max_align_t __space[(1023 + sizeof (max_align_t)) / sizeof (max_align_t)];
+};
+
+/* Initializes *BUFFER so that BUFFER->data points to BUFFER->__space
+   and BUFFER->length reflects the available space.  */
+static inline void
+scratch_buffer_init (struct scratch_buffer *buffer)
+{
+  buffer->data = buffer->__space;
+  buffer->length = sizeof (buffer->__space);
+}
+
+/* Deallocates *BUFFER (if it was heap-allocated).  */
+static inline void
+scratch_buffer_free (struct scratch_buffer *buffer)
+{
+  if (buffer->data != buffer->__space)
+    free (buffer->data);
+}
+
+/* Grow *BUFFER by some arbitrary amount.  The buffer contents is NOT
+   preserved.  Return true on success, false on allocation failure (in
+   which case the old buffer is freed).  On success, the new buffer is
+   larger than the previous size.  On failure, *BUFFER is deallocated,
+   but remains in a free-able state, and errno is set.  */
+bool __libc_scratch_buffer_grow (struct scratch_buffer *buffer);
+libc_hidden_proto (__libc_scratch_buffer_grow)
+
+/* Alias for __libc_scratch_buffer_grow.  */
+static __always_inline bool
+scratch_buffer_grow (struct scratch_buffer *buffer)
+{
+  return __glibc_likely (__libc_scratch_buffer_grow (buffer));
+}
+
+/* Like __libc_scratch_buffer_grow, but preserve the old buffer
+   contents on success, as a prefix of the new buffer.  */
+bool __libc_scratch_buffer_grow_preserve (struct scratch_buffer *buffer);
+libc_hidden_proto (__libc_scratch_buffer_grow_preserve)
+
+/* Alias for __libc_scratch_buffer_grow_preserve.  */
+static __always_inline bool
+scratch_buffer_grow_preserve (struct scratch_buffer *buffer)
+{
+  return __glibc_likely (__libc_scratch_buffer_grow_preserve (buffer));
+}
+
+/* Grow *BUFFER so that it can store at least NELEM elements of SIZE
+   bytes.  The buffer contents are NOT preserved.  Both NELEM and SIZE
+   can be zero.  Return true on success, false on allocation failure
+   (in which case the old buffer is freed, but *BUFFER remains in a
+   free-able state, and errno is set).  It is unspecified whether this
+   function can reduce the array size.  */
+bool __libc_scratch_buffer_set_array_size (struct scratch_buffer *buffer,
+					   size_t nelem, size_t size);
+libc_hidden_proto (__libc_scratch_buffer_set_array_size)
+
+/* Alias for __libc_scratch_set_array_size.  */
+static __always_inline bool
+scratch_buffer_set_array_size (struct scratch_buffer *buffer,
+			       size_t nelem, size_t size)
+{
+  return __glibc_likely (__libc_scratch_buffer_set_array_size
+			 (buffer, nelem, size));
+}
+
+#endif /* _SCRATCH_BUFFER_H */

--- a/rpm/scratchbox2.spec
+++ b/rpm/scratchbox2.spec
@@ -1,6 +1,6 @@
 Summary:	Scratchbox2 crosscompiling environment
 License:	LGPLv2
-URL:		https://git.sailfishos.org/mer-core/scratchbox2
+URL:		https://github.com/sailfishos/scratchbox2
 Name:		scratchbox2
 Version:	2.3.90+git58
 Release:	0


### PR DESCRIPTION
We had ancient glob implementation from glibc 2.7, which doesn't include broken symlinks in filename expansion. This breaks newer rpm which dropped its own glob implementation, which did. This mismatch breaks some `%files` section globs including wildcards matching some dead symlinks. For example, `%{_bindir}\*` when it contains absolute symlinks to `/usr/bin/...` which then don't exist in the compilation environment.

Fix by updating the glob from glibc 2.42, which behaves correctly.