### PR TITLE
Match constness with certain string functions. JB#63834

### DIFF
--- a/network/net_rules.c
+++ b/network/net_rules.c
@@ -61,7 +61,7 @@ static int compare_ipv4_addrs(const char *address, const char *address_pattern)
 	 * - "1.2.3.0/24" requires that the network part matches.
 	*/
 	if (isdigit(*address_pattern)) {
-		char *s_mask = NULL;
+		const char *s_mask = NULL;
 
 		s_mask = strchr(address_pattern, '/');
 		if (s_mask) {
@@ -143,7 +143,7 @@ static int compare_ipv6_addrs(const char *address, const char *address_pattern)
 		 * - "3fff:ffff:8:9" requires an exact match
 		 * - "3fff:ffff::8:9/32" requires that the network part matches.
 		*/
-		char *s_mask = NULL;
+		const char *s_mask = NULL;
 
 		s_mask = strchr(address_pattern, '/');
 		if (s_mask) {

--- a/preload/procfs.c
+++ b/preload/procfs.c
@@ -164,7 +164,7 @@ static char *symlink_for_exe_path(
 	mkdir_nomap_nolog(pathbuf, 0755);
 
 	for (cp=exe_path; cp && *cp; ) {
-		char	*next_slash = strchr(cp+1, '/');
+		const char *next_slash = strchr(cp+1, '/');
 
 		/* This algorithm is not too efficient (first copies
 		 * everything, then cuts it), but usually "exe_path"

--- a/preload/vperm_uid_gid_gates.c
+++ b/preload/vperm_uid_gid_gates.c
@@ -54,7 +54,7 @@ static uid_t	v_real_egid = 0;
 
 static void initialize_simulated_ids(void)
 {
-	const char	*cp;
+	char	*cp;
 	int		i1,i2,i3,i4;
 
 	if (vperm_simulated_ids.initialized) return;

--- a/utils/sb2-show.c
+++ b/utils/sb2-show.c
@@ -301,7 +301,7 @@ static int diff_strvecs(char **orig_vec, char **new_vec,
 				printf("%15s: %s\n", "unmodified", *op);
 			op++, np++;
 		} else {
-			const char *cp = strchr(*op,'=');
+			char *cp = strchr(*op,'=');
 			int namelen = 0;
 
 			if (cp) namelen = cp - *op;


### PR DESCRIPTION
Update to glibc 2.43 makes many string functions const-preserving, so check and fix up the types where they are used.