### PR TITLE
Various fixes for format strings in sb2_log

### DIFF
--- a/execs/exec_map_script_interp.c
+++ b/execs/exec_map_script_interp.c
@@ -19,7 +19,7 @@
  * Same result code as Lua returned, the return value:
  *  0: argv / envp were modified; mapped_interpreter was set
  *  1: argv / envp were not modified; mapped_interpreter was set
- *  2: argv / envp were not modified; caller should call ordinary path 
+ *  2: argv / envp were not modified; caller should call ordinary path
  *      mapping to find the interpreter
  *  -1: deny exec.
 */
@@ -35,7 +35,7 @@ int exec_map_script_interpreter(
 	char	   **mapped_interpreter_p)
 {
 	const char		*log_level = NULL;
-	uint32_t /*FIXME*/	rule_list_offs = 0;
+	ruletree_object_offset_t  rule_list_offs = 0;
 
 	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: interp=%s, interp_arg=%s policy=%s ", __func__,
 		interpreter, (interp_arg?interp_arg:""), exec_policy_name);
@@ -91,5 +91,3 @@ int exec_map_script_interpreter(
          * use ordinary path mapping to find it */
 	return(2);
 }
-
-

--- a/execs/exec_policy_ruletree.c
+++ b/execs/exec_policy_ruletree.c
@@ -28,13 +28,13 @@ exec_policy_handle_t     find_exec_policy_handle(const char *policyname)
 {
 	exec_policy_handle_t	eph;
 	const char *v[4];
-	
+
 	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: find %s", __func__, policyname);
 	v[0] = "exec_policy";
 	v[1] = sbox_session_mode ? sbox_session_mode : ruletree_catalog_get_string("MODES", "#default");
 	v[2] = policyname;
 	v[3] = NULL;
-	
+
 	eph.exec_policy_offset = ruletree_catalog_vget(v);
 	SB_LOG(SB_LOGLEVEL_DEBUG,
 		"%s: Handle for (%s,%s) = %u", __func__,
@@ -54,10 +54,10 @@ const char *exec_policy_get_string(exec_policy_handle_t eph,
 		str = offset_to_ruletree_string_ptr(offs, NULL);
 		if (str) {
 			SB_LOG(SB_LOGLEVEL_NOISE,
-				"%s: %s='%s'", __func__, s_name, str, fldoffs);
+				"%s: %s='%s' o=%zu", __func__, s_name, str, fldoffs);
 		} else {
 			SB_LOG(SB_LOGLEVEL_NOISE,
-				"%s: No %s", __func__, s_name, fldoffs);
+				"%s: No %s o=%zu", __func__, s_name, fldoffs);
 		}
                 return(str);
 	}
@@ -75,7 +75,7 @@ int exec_policy_get_boolean(exec_policy_handle_t eph,
 			eph.exec_policy_offset, b_name);
 		uip = ruletree_get_pointer_to_boolean(offs);
                 SB_LOG(SB_LOGLEVEL_NOISE,
-                        "%s: @%u = *%p = %d",
+                        "%s: @%u = *%p = %d o=%zu",
 			__func__, offs, uip, (uip ? *uip : 999), fldoffs);
                 return(uip ? * uip : 0);
 	}
@@ -93,7 +93,7 @@ int exec_policy_get_uint32(exec_policy_handle_t eph,
 			eph.exec_policy_offset, u_name);
 		uip = ruletree_get_pointer_to_uint32(offs);
 		SB_LOG(SB_LOGLEVEL_NOISE,
-			"%s: @%u = *%p = %u",
+			"%s: @%u = *%p = %u o=%zu",
 			__func__, offs, uip, (uip ? *uip : 0), fldoffs);
 		return(uip ? *uip : 0);
 	}
@@ -109,9 +109,8 @@ ruletree_object_offset_t exec_policy_get_rules(exec_policy_handle_t eph,
 		offs = ruletree_catalog_find_value_from_catalog(
 			eph.exec_policy_offset, r_name);
                 SB_LOG(SB_LOGLEVEL_NOISE,
-                        "%s: @%u", __func__, offs, fldoffs);
+                        "%s: @%u o=%zu", __func__, offs, fldoffs);
                 return(offs);
 	}
 	return(0);
 }
-

--- a/execs/exec_policy_ruletree.c
+++ b/execs/exec_policy_ruletree.c
@@ -37,7 +37,7 @@ exec_policy_handle_t     find_exec_policy_handle(const char *policyname)
 
 	eph.exec_policy_offset = ruletree_catalog_vget(v);
 	SB_LOG(SB_LOGLEVEL_DEBUG,
-		"%s: Handle for (%s,%s) = %u", __func__,
+		"%s: Handle for (%s,%s) = %" PRI_SB_RTOO , __func__,
 		v[1], v[2], eph.exec_policy_offset);
 	return(eph);
 }
@@ -75,7 +75,7 @@ int exec_policy_get_boolean(exec_policy_handle_t eph,
 			eph.exec_policy_offset, b_name);
 		uip = ruletree_get_pointer_to_boolean(offs);
                 SB_LOG(SB_LOGLEVEL_NOISE,
-                        "%s: @%u = *%p = %d o=%zu",
+                        "%s: @%" PRI_SB_RTOO " = *%p = %d o=%zu",
 			__func__, offs, uip, (uip ? *uip : 999), fldoffs);
                 return(uip ? * uip : 0);
 	}
@@ -93,7 +93,7 @@ int exec_policy_get_uint32(exec_policy_handle_t eph,
 			eph.exec_policy_offset, u_name);
 		uip = ruletree_get_pointer_to_uint32(offs);
 		SB_LOG(SB_LOGLEVEL_NOISE,
-			"%s: @%u = *%p = %u o=%zu",
+			"%s: @%" PRI_SB_RTOO " = *%p = %" PRIu32 " o=%zu",
 			__func__, offs, uip, (uip ? *uip : 0), fldoffs);
 		return(uip ? *uip : 0);
 	}
@@ -109,7 +109,7 @@ ruletree_object_offset_t exec_policy_get_rules(exec_policy_handle_t eph,
 		offs = ruletree_catalog_find_value_from_catalog(
 			eph.exec_policy_offset, r_name);
                 SB_LOG(SB_LOGLEVEL_NOISE,
-                        "%s: @%u o=%zu", __func__, offs, fldoffs);
+                        "%s: @%" PRI_SB_RTOO " o=%zu", __func__, offs, fldoffs);
                 return(offs);
 	}
 	return(0);

--- a/execs/exec_policy_selection.c
+++ b/execs/exec_policy_selection.c
@@ -16,6 +16,7 @@
 
 #include <config.h>
 
+#include <inttypes.h>
 #include <sys/mman.h>
 
 #include <mapping.h>
@@ -28,7 +29,7 @@
 
 
 /* FIXME: This is currently a slightly modified copy of ruletree_test_path_match()
- *    
+ *
  * Returns min.path length if a match is found, otherwise returns -1 */
 static int test_path_match(const char *full_path, size_t full_path_len,
 	uint32_t selector_type, ruletree_object_offset_t selector_offs)
@@ -39,10 +40,10 @@ static int test_path_match(const char *full_path, size_t full_path_len,
 	uint32_t	selector_len;
 
 	if (!selector_type || !full_path) {
-		SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match fails"); 
+		SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match fails");
 		return(-1);
 	}
-	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match (%s), type=%d", 
+	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match (%s), type=%d",
 		full_path, selector_type);
 
 	selector = offset_to_ruletree_string_ptr(selector_offs,
@@ -91,7 +92,7 @@ static int test_path_match(const char *full_path, size_t full_path_len,
 	}
 
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"%s: '%s' (%u), '%s' (%u) => %d (%s)",
+		"%s: '%s' (%zu), '%s' (%" PRIu32 ") => %d (%s)",
 		__func__, full_path, full_path_len, selector, selector_len, result, match_type);
 	return(result);
 }
@@ -157,4 +158,3 @@ const char *find_exec_policy_name(const char *mapped_path, const char *virtual_p
 		__func__, modename);
 	return(NULL);
 }
-

--- a/execs/exec_preprocess.c
+++ b/execs/exec_preprocess.c
@@ -67,7 +67,7 @@ static int add_elements_to_argv(
 
 		str_offs = ruletree_objectlist_get_item(add_tbl_offs, j);
 		str = offset_to_ruletree_string_ptr(str_offs, NULL);
-		
+
 		argv[add_idx] = strdup(str);
 		SB_LOG(SB_LOGLEVEL_NOISE,
 			"%s: add from %s to argv[%d] = '%s'",
@@ -163,7 +163,7 @@ static ruletree_exec_preprocessing_rule_t *find_exec_preprocessing_rule(
 				if (execpp_rule->rtree_xpr_binary_name_offs) {
 					const char *rule_bin_name;
 					uint32_t rule_bin_name_len;
-					
+
 					rule_bin_name = offset_to_ruletree_string_ptr(
 						execpp_rule->rtree_xpr_binary_name_offs,
 						&rule_bin_name_len);
@@ -219,7 +219,7 @@ int apply_exec_preprocessing_rules(char **file, char ***argv, char ***envp)
 				(use_gcc_rules ? "gcc" : "misc"));
 
 			SB_LOG(SB_LOGLEVEL_DEBUG,
-				"%s: argvmods rules @%u, use_gcc_rules=%d",
+				"%s: argvmods rules @%" PRI_SB_RTOO ", use_gcc_rules=%d",
 				__func__, argvmods_rules_offs, use_gcc_rules);
                 }
 	}
@@ -387,4 +387,3 @@ int apply_exec_preprocessing_rules(char **file, char ***argv, char ***envp)
 
 	return(0);
 }
-

--- a/execs/exec_ruletree_maint.c
+++ b/execs/exec_ruletree_maint.c
@@ -62,7 +62,7 @@ ruletree_object_offset_t add_exec_preprocessing_rule_to_ruletree(
 	ruletree_exec_preprocessing_rule_t new_rule;
 
 	memset(&new_rule, 0, sizeof(new_rule));
-	
+
 	if (binary_name) {
 		new_rule.rtree_xpr_binary_name_offs = append_string_to_ruletree_file(binary_name);
 	}
@@ -78,9 +78,9 @@ ruletree_object_offset_t add_exec_preprocessing_rule_to_ruletree(
 
 	rule_location = append_struct_to_ruletree_file(&new_rule, sizeof(new_rule),
 		SB2_RULETREE_OBJECT_TYPE_EXEC_PP_RULE);
-	
+
 	SB_LOG(SB_LOGLEVEL_DEBUG,
-		"Added exec preprocessing rule: %s @ %u",
+		"Added exec preprocessing rule: %s @ %" PRI_SB_RTOO,
 			binary_name, rule_location);
 
 	return(rule_location);
@@ -96,7 +96,7 @@ ruletree_object_offset_t add_exec_policy_selection_rule_to_ruletree(
 	ruletree_exec_policy_selection_rule_t new_rule;
 
 	memset(&new_rule, 0, sizeof(new_rule));
-	
+
 	new_rule.rtree_xps_type = ruletype;
 	new_rule.rtree_xps_flags = flags;
 	if (selector) {
@@ -108,11 +108,10 @@ ruletree_object_offset_t add_exec_policy_selection_rule_to_ruletree(
 
 	rule_location = append_struct_to_ruletree_file(&new_rule, sizeof(new_rule),
 		SB2_RULETREE_OBJECT_TYPE_EXEC_SEL_RULE);
-	
+
 	SB_LOG(SB_LOGLEVEL_DEBUG,
-		"Added exec policy selection rule @ %u",
+		"Added exec policy selection rule @ %" PRI_SB_RTOO,
 			rule_location);
 
 	return(rule_location);
 }
-

--- a/execs/sb_exec.c
+++ b/execs/sb_exec.c
@@ -6,15 +6,15 @@
  */
 
 /* This file contains the "exec core" of SB2; Being able to alter
- * how the execl(), execve(), etc. exec-class functions are handled 
+ * how the execl(), execve(), etc. exec-class functions are handled
  * is one of the most important features of SB2.
  *
  * Brief description of the algorithm follows:
- * 
+ *
  * 0. When an application wants to execute another program, it makes a call
  *    to one of execl(), execle(), execlp(), execv(), execve(), execvp(),
  *    posix_spawn() or posix_spawnp().
- *    That call will be handled by one of the gate functions in 
+ *    That call will be handled by one of the gate functions in
  *    preload/libsb2.c. Eventually, the gate function will call "do_exec()"
  *    from this file; do_exec() calls prepare_exec() and that is the place
  *    where everything interesting happens:
@@ -23,13 +23,13 @@
  *    as Lua code, and also known as the argv&envp mangling code).
  *    The purpose of the preprocessing phase is to determine WHAT FILE needs
  *    to be executed. And that might well be something else than what the
- *    application requested: For example, an attempt to run /usr/bin/gcc might 
+ *    application requested: For example, an attempt to run /usr/bin/gcc might
  *    be replaced by a path to the cross compiler (e.g. /some/path/to/cross-gcc)
  *    Arguments may also be added, deleted, or modified during preprocessing.
  *
  * 2. Second, prepare_exec() needs to determine WHERE THE FILE IS. It makes a
- *    call the regular path mapping engine of SB2 to get a real path to 
- *    the program. (For example, "/bin/ls" might be replaced by 
+ *    call the regular path mapping engine of SB2 to get a real path to
+ *    the program. (For example, "/bin/ls" might be replaced by
  *    "/opt/tools_root/bin/ls" by the path mapping engine).
  *    This step involves applying the path mapping Lua code (A notable
  *    side-effect of that is that the Lua code also returns an "execution
@@ -42,15 +42,15 @@
  *    file. Based on the type of the file, prepare_exec() will do one of the
  *    following:
  *
- *    4a. For scripts (files starting with #!), script interpreter name 
+ *    4a. For scripts (files starting with #!), script interpreter name
  *        will be read from the file, mapped by exec_map_script_interpreter()
  *	  (in exec_map_script_interp.c), and once the interpreter
- *	  location has been found, the parameters will be processed again by 
+ *	  location has been found, the parameters will be processed again by
  *	  prepare_exec().
  *        This solution supports location- and exec policy based mapping
  *	  of the script interpreter.
  *
- *    4b. For native binaries, an additional call to an exec postprocessing 
+ *    4b. For native binaries, an additional call to an exec postprocessing
  *        function will be made, because the type of the file is not enough
  *        to spefify the environment that needs to be used for the file:
  *        This is the place where the "exec policy" rules (determined by step
@@ -60,7 +60,7 @@
  *         - native binaries that are compiled for the host system can
  *           be started directly (for example, the sb2-show command that
  *           belongs to SB2's utilities)
- *         - an exception: host's binaries which have SUID, SGID or 
+ *         - an exception: host's binaries which have SUID, SGID or
  *           special capabilities need to be started by invoking the
  *           dynamic linker explicitly (otherwise this LD_PRELOAD library
  *           won't be loaded, etc)
@@ -68,7 +68,7 @@
  *           dynamic libraries from a different place (e.g.
  *           "/opt/tools_root/bin/ls" may need to use libraries from
  *           "/opt/tools_root/lib", instead of using them from "/lib").
- *           This is implemented by making an explicit call to the 
+ *           This is implemented by making an explicit call to the
  *           dynamic loader (ld.so) to start the program, with additional
  *           options for ld.so.
  *         - if the target architecture is the same as the host architecture,
@@ -150,9 +150,9 @@
 # error Unsupported host CPU architecture
 #endif
 
-#ifndef EM_AARCH64 
-#define EM_AARCH64	183 
-#endif 
+#ifndef EM_AARCH64
+#define EM_AARCH64	183
+#endif
 
 struct target_info {
 	char name[8];
@@ -400,17 +400,17 @@ static enum binary_type inspect_binary(const char *filename,
 			goto _out;
 		}
 
-		if (sb1_bug_emulation_mode && 
+		if (sb1_bug_emulation_mode &&
 		    strchr(sb1_bug_emulation_mode,'x')) {
-			/* the old scratchbox didn't have the x-bit check, so 
-			 * having R-bit set was enough to exec a file. That is 
-			 * of course wrong, but unfortunately there are now 
-			 * lots of packages out there that have various scripts 
+			/* the old scratchbox didn't have the x-bit check, so
+			 * having R-bit set was enough to exec a file. That is
+			 * of course wrong, but unfortunately there are now
+			 * lots of packages out there that have various scripts
 			 * with wrong permissions.
-			 * We'll provide a compatibility mode, so that broken 
+			 * We'll provide a compatibility mode, so that broken
 			 * packages can be built.
 			 *
-			 * an 'x' in the env.var. means that we should not 
+			 * an 'x' in the env.var. means that we should not
 			 * worry about x-bits when checking exec parmissions
 			*/
 			if (access_nomap_nolog(filename, R_OK) < 0) {
@@ -421,12 +421,12 @@ static enum binary_type inspect_binary(const char *filename,
 				errno = saved_errno;
 				goto _out;
 			}
-			SB_LOG(SB_LOGLEVEL_WARNING, 
+			SB_LOG(SB_LOGLEVEL_WARNING,
 				"X permission missing, but exec enabled by"
 				" SB1 bug emulation mode ('%s')", filename);
 		} else {
 			/* The normal case:
-			 * can't execute it. Possible errno codes from access() 
+			 * can't execute it. Possible errno codes from access()
 			 * are all possible from execve(), too, so there is no
 			 * need to convert errno.
 			*/
@@ -631,7 +631,7 @@ static int prepare_hashbang(
 	new_argv = calloc(argc + 3, sizeof(char *));
 
 	/* skip any initial whitespace following "#!" */
-	for (i = 2; (hashbang[i] == ' ' 
+	for (i = 2; (hashbang[i] == ' '
 			|| hashbang[i] == '\t') && i < c; i++)
 		;
 
@@ -668,7 +668,7 @@ static int prepare_hashbang(
 	}
 	new_argv[n] = NULL;
 
-	/* Now we need to update __SB2_ORIG_BINARYNAME to point to 
+	/* Now we need to update __SB2_ORIG_BINARYNAME to point to
 	 * the unmapped script interpreter (exec_map_script_interpreter
 	 * may change it again (not currently, but in the future)
 	*/
@@ -679,7 +679,7 @@ static int prepare_hashbang(
 	exec_policy_handle_t     eph = find_exec_policy_handle(exec_policy_name);
 	int c_mapping_result_code;
 	const char *c_new_exec_policy_name = NULL;
-	
+
 	c_mapping_result_code = exec_map_script_interpreter(eph, exec_policy_name,
 		interpreter, interp_arg, *mapped_file,
 		orig_file, new_argv, &c_new_exec_policy_name, &mapped_interpreter);
@@ -752,7 +752,7 @@ static int prepare_hashbang(
 	    mapped_binaryname);
 	free(mapped_binaryname);
 	free(tmp);
-	
+
 	SB_LOG(SB_LOGLEVEL_DEBUG, "prepare_hashbang(): interpreter=%s,"
 			"mapped_interpreter=%s", interpreter,
 			mapped_interpreter);
@@ -857,7 +857,7 @@ static char **prepare_envp_for_do_exec(const char *orig_file,
 	/* SBOX_SESSION_* is now preserved properly (these are practically
 	 * read-only variables now)
 	*/
-	
+
 	/* if we have LD_PRELOAD env var set, make sure the new my_envp
 	 * has it as well
 	 */
@@ -900,7 +900,7 @@ static char **prepare_envp_for_do_exec(const char *orig_file,
 				has_sbox_session_dir = 1;
 				if (strcmp(*p+sbox_session_dir_varname_len+1,
 					sbox_session_dir)) {
-						SB_LOG(SB_LOGLEVEL_WARNING, 
+						SB_LOG(SB_LOGLEVEL_WARNING,
 							"Detected attempt to set %s,"
 							" restored to %s",
 							*p, sbox_session_dir);
@@ -913,7 +913,7 @@ static char **prepare_envp_for_do_exec(const char *orig_file,
 				has_sbox_mapping_method = 1;
 				if (strcmp(*p+sbox_mapping_method_varname_len+1,
 					sbox_mapping_method)) {
-						SB_LOG(SB_LOGLEVEL_WARNING, 
+						SB_LOG(SB_LOGLEVEL_WARNING,
 							"Detected attempt to set %s,"
 							" restored to %s",
 							*p, sbox_mapping_method);
@@ -933,12 +933,12 @@ static char **prepare_envp_for_do_exec(const char *orig_file,
 	 * it is usually a consequency of complete reset of the environment.
 	 * Just restore those. */
 	if (!has_sbox_session_dir) {
-		SB_LOG(SB_LOGLEVEL_NOTICE, 
+		SB_LOG(SB_LOGLEVEL_NOTICE,
 			"Detected attempt to clear SBOX_SESSION_DIR, "
 				"restored to %s", sbox_session_dir);
 	}
 	if (sbox_mapping_method && !has_sbox_mapping_method) {
-		SB_LOG(SB_LOGLEVEL_NOTICE, 
+		SB_LOG(SB_LOGLEVEL_NOTICE,
 			"Detected attempt to clear SBOX_MAPPING_METHOD, "
 				"restored to %s", sbox_mapping_method);
 	}
@@ -1143,12 +1143,12 @@ static char **prepare_envp_for_do_exec(const char *orig_file,
 
 /* compare vectors of strings and log if there are any changes.
  * TO BE IMPROVED: a more clever algorithm would be nice, something
- * that would log only the modified parts... now this displays 
- * everything if something was changed, which easily creates 
+ * that would log only the modified parts... now this displays
+ * everything if something was changed, which easily creates
  * a *lot* of noise if SB_LOGLEVEL_NOISE is enabled.
 */
-static void compare_and_log_strvec_changes(const char *vecname, 
-	char *const *orig_strv, char *const *new_strv) 
+static void compare_and_log_strvec_changes(const char *vecname,
+	char *const *orig_strv, char *const *new_strv)
 {
 	char *const *ptr2old = orig_strv;
 	char *const *ptr2new = new_strv;
@@ -1165,20 +1165,20 @@ static void compare_and_log_strvec_changes(const char *vecname,
 		strv_modified = 1;
 	}
 	if (strv_modified) {
-		SB_LOG(SB_LOGLEVEL_DEBUG, "%s[] was modified", vecname); 
+		SB_LOG(SB_LOGLEVEL_DEBUG, "%s[] was modified", vecname);
 		if (SB_LOG_IS_ACTIVE(SB_LOGLEVEL_NOISE)) {
 			int	i;
-			for (i = 0, ptr2new = new_strv; 
+			for (i = 0, ptr2new = new_strv;
 			    *ptr2new;
 			    i++, ptr2new++) {
-				SB_LOG(SB_LOGLEVEL_NOISE, 
+				SB_LOG(SB_LOGLEVEL_NOISE,
 					"[%d]='%s'", i,
 					*ptr2new);
 			}
 		}
 	} else {
-		SB_LOG(SB_LOGLEVEL_NOISE, 
-			"%s[] was not modified", vecname); 
+		SB_LOG(SB_LOGLEVEL_NOISE,
+			"%s[] was not modified", vecname);
 	}
 }
 
@@ -1235,7 +1235,7 @@ static void change_environment_variable(
 
 		SB_LOG(SB_LOGLEVEL_DEBUG, "Changed: %s", new_value_buf);
 	} else {
-		SB_LOG(SB_LOGLEVEL_DEBUG, "Failed to change %s%s", 
+		SB_LOG(SB_LOGLEVEL_DEBUG, "Failed to change %s%s",
 			var_prefix, new_value);
 	}
 }
@@ -1337,7 +1337,7 @@ static int exec_policy_force_cpu_transparency(const char *exec_policy_name,
 		return 0;
 
 	exec_flags = EXEC_POLICY_GET_UINT32(eph, exec_flags);
-	SB_LOG(SB_LOGLEVEL_DEBUG, "exec_policy: %s, exec_flags: %u",
+	SB_LOG(SB_LOGLEVEL_DEBUG, "exec_policy: %s, exec_flags: %" PRIu32,
 		exec_policy_name, exec_flags);
 
 	if (!(exec_flags & SB2_EXEC_FLAGS_FORCE_CPU_TRANSPARENCY))
@@ -1419,7 +1419,7 @@ static int prepare_exec(const char *exec_fn_name,
 	tmp = strdup(orig_file);
 	binaryname = strdup(basename(tmp)); /* basename may modify *tmp */
 	free(tmp);
-	
+
 	my_file = strdup(orig_file);
 
 	my_argv = duplicate_argv(orig_argv);
@@ -1475,7 +1475,7 @@ static int prepare_exec(const char *exec_fn_name,
 			ret = -1;
 			goto out;
 		}
-			
+
 		free_mapping_results(&mapping_result);
 
 		SB_LOG(SB_LOGLEVEL_DEBUG,
@@ -1713,13 +1713,13 @@ int do_exec(int *result_errno_ptr,
 			SB_LOG(SB_LOGLEVEL_DEBUG,
 				"EXEC/Orig.args: %s : %s", orig_file, buf);
 			free(buf);
-		
+
 			/* create a copy of intended environment for logging,
 			 * before preprocessing */
 			my_envp_copy = prepare_envp_for_do_exec(orig_file,
 				binaryname, orig_envp);
 		}
-		
+
 		new_envp = prepare_envp_for_do_exec(orig_file, binaryname, orig_envp);
 
 		r = prepare_exec(exec_fn_name, NULL/*exec_policy_name: not yet known*/,
@@ -1917,4 +1917,3 @@ char *sb2show__binary_type__(const char *filename)
 	}
 	return(strdup(result));
 }
-

--- a/include/rule_tree.h
+++ b/include/rule_tree.h
@@ -11,7 +11,7 @@
  * to memory, and use it (R/O) without locking anything.
  *
  * Since the file may be mapped to any address, pointers
- * can not be used in the rule tree. Instead, offsets 
+ * can not be used in the rule tree. Instead, offsets
  * (relative to the beginning of the file) are used.
 */
 
@@ -19,9 +19,11 @@
 #define SB2_RULETREE_H__
 
 #include <stdint.h>
+#include <inttypes.h>
 
 /* object offset must be an unsigned type: */
 typedef uint32_t ruletree_object_offset_t;
+#define PRI_SB_RTOO PRIu32
 
 /* Every object in the rule tree begins with an object header:
  * (all structures contain this as the first member, etc) */
@@ -203,7 +205,7 @@ typedef struct ruletree_uint32_s {
 #define SB2_RULETREE_FSRULE_ACTION_UNION_DIR		251
 #define SB2_RULETREE_FSRULE_ACTION_IF_EXISTS_IN         252
 
-/* auxiliar conditions */ 
+/* auxiliar conditions */
 #define SB2_RULETREE_FSRULE_CONDITION_IF_ACTIVE_EXEC_POLICY_IS 301
 #define SB2_RULETREE_FSRULE_CONDITION_IF_REDIRECT_IGNORE_IS_ACTIVE 302
 #define SB2_RULETREE_FSRULE_CONDITION_IF_REDIRECT_FORCE_IS_ACTIVE 303
@@ -353,7 +355,7 @@ ruletree_object_offset_t add_exec_policy_selection_rule_to_ruletree(
         const char      *selector,
         const char      *exec_policy_name,
 	uint32_t	flags);
- 
+
 /* ------------ net rule maintenance routines ------------ */
 ruletree_object_offset_t add_net_rule_to_ruletree(
 	ruletree_net_rule_t	*rule);

--- a/include/sb2.h
+++ b/include/sb2.h
@@ -54,7 +54,7 @@ struct sb2context {
 
 /* Library interface version string:
  *
- * Originally, This version string was used to check that the lua scripts offer 
+ * Originally, This version string was used to check that the lua scripts offer
  * what the C files expect, and v.v.
  * Now, when lua is not anymore included in libsb2, it is only used
  * to identify the C interface (e.g. for sb2-show), and to locate
@@ -79,9 +79,9 @@ struct sb2context {
  * * Differences between "63" and "62"
  *   - sb_find_exec_policy() has been removed.
  * * Differences between "65" and "63"
- *   - The Lua side of the mapping engine now returns "flags" (bitmask) 
+ *   - The Lua side of the mapping engine now returns "flags" (bitmask)
  *     to the C code; functions used to return separate booleans.
- *   - (Additionally, due to a previous bugfix in path_exists(), forcing 
+ *   - (Additionally, due to a previous bugfix in path_exists(), forcing
  *     the library to be upgraded is a good thing to do in any case!)
  * * Differences between "66" and "65"
  *   - LD_PRELOAD and LD_LIBRARY_PATH environment variables
@@ -130,7 +130,7 @@ struct sb2context {
  * * New in version "96":
  *   - uint32 and boolean types in ruletree + related interf.functions
  * * New in version "97":
- *   - "sblib.*" functions 
+ *   - "sblib.*" functions
  * * New in version "98":
  *   - Lua fucntion sbox_execve_preprocess() was removed
  *     exec preprocessing code is now implemented in C)
@@ -154,7 +154,7 @@ struct sb2context {
  *     not directly related to Lua/C interface: Rule tree
  *     header was changed (vrs 6).
  * * 126:
- *     sbox_map_network_addr() and sb.test_net_addr_match() 
+ *     sbox_map_network_addr() and sb.test_net_addr_match()
  *     were removed.
  * * 127:
  *     exec postprocessing is completely implemented in C,
@@ -234,7 +234,8 @@ extern int sblog_level_name_to_number(const char *level_str);
 extern void sblog_vprintf_line_to_logfile(const char *file, int line,
 	int level, const char *format, va_list ap);
 extern void sblog_printf_line_to_logfile(const char *file, int line,
-	int level, const char *format,...);
+					 int level, const char *format,
+					 ...) __attribute__ ((format(printf, 4, 5)));
 
 extern int sb_loglevel__; /* do not access directly */
 extern int sb_log_initial_pid__; /* current PID will be recorded here

--- a/network/net_rules.c
+++ b/network/net_rules.c
@@ -25,6 +25,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <lua.h>
 #include <lualib.h>
@@ -36,6 +37,7 @@
 
 #include "libsb2.h"
 #include "exported.h"
+
 
 /* ========== find & execute a network rule for given address: ========== */
 
@@ -274,7 +276,7 @@ static ruletree_net_rule_t *find_net_rule(
 		}
 
 		/* Lua:
-		 *	
+		 *
 		 *        if rule and rule.port and rule.port ~= orig_port then
 		 *                rule = nil
 		 *        end
@@ -325,7 +327,7 @@ static ruletree_net_rule_t *find_net_rule(
 				continue;
 			}
 		}
-		
+
 		/* Lua:
 		 *        if rule and rule.address then
 		 *                res,msg = sb.test_net_addr_match(addr_type,
@@ -358,11 +360,11 @@ static ruletree_net_rule_t *find_net_rule(
 		*/
 		if (rule->rtree_net_rules) {
 			SB_LOG(SB_LOGLEVEL_NOISE,
-				"%s: [%d] => more rules @%d", __func__, rule->rtree_net_rules);
+				"%s: [%d] => more rules @"PRIu32, __func__, rule->rtree_net_rules);
 			return (find_net_rule(rule->rtree_net_rules, realfnname,
 				addr_type, orig_dst_addr, orig_port, binary_name));
 		}
-		
+
 		/* Lua:
 		 *          if rule then
 		 *                return rule
@@ -390,7 +392,7 @@ static int apply_net_rule(
 	int *result_port)
 {
 	SB_LOG(SB_LOGLEVEL_DEBUG, "%s", __func__);
-	
+
 	/*	if rule.new_port then
 	 *		dst_port = rule.new_port
 	 *		sb.log("debug", "network port set to "..
@@ -402,7 +404,7 @@ static int apply_net_rule(
 		SB_LOG(SB_LOGLEVEL_NOISE, "%s: port = %d",
 			__func__, rule->rtree_net_new_port);
 	}
-	
+
 	/*	if rule.new_address then
 	 *		dst_addr = rule.new_address
 	 *		sb.log("debug", "network addr set to "..
@@ -425,7 +427,7 @@ static int apply_net_rule(
 	 *			return "EPERM", orig_dst_addr, orig_port,
 	 *				rule.log_level, rule.log_msg
 	 *		end
-	 *		return "OK", dst_addr, dst_port, 
+	 *		return "OK", dst_addr, dst_port,
 	 *				rule.log_level, rule.log_msg
 	 *	else
 	 *		if not rule.deny then
@@ -460,7 +462,7 @@ static int apply_net_rule(
 }
 
 /* Returns:
- *  - nonzero: value for errno, result_addr_buf and *result_port 
+ *  - nonzero: value for errno, result_addr_buf and *result_port
  *    contain unknown values
  *  - zero: address was mapped, results in result_addr_buf and *result_port
 */
@@ -553,4 +555,3 @@ int sb2show__map_network_addr__(
 	*addr_bufp = strdup(result_buf);
 	return(res);
 }
-

--- a/pathmapping/pathlistutils.c
+++ b/pathmapping/pathlistutils.c
@@ -60,7 +60,7 @@ struct path_entry *append_path_entries(
 	struct path_entry *new_entries)
 {
 	struct path_entry *work = head;
-	
+
 	if (!head) return(new_entries);
 
 	/* move work to point to last component of "head" */
@@ -123,7 +123,7 @@ char *path_entries_to_string_until(
 	if (flags & PATH_FLAGS_HAS_TRAILING_SLASH) {
 		char *cp = buf;
 		/* point to last char in buf */
-		while (*cp && cp[1]) cp++; 
+		while (*cp && cp[1]) cp++;
 		if (*cp != '/') strcat(buf, "/");
 	}
 
@@ -273,7 +273,7 @@ struct path_entry *duplicate_path_entries_until(
 		new->pe_next = NULL;
 		dest_path_ptr = new;
 		SB_LOG(SB_LOGLEVEL_NOISE3,
-			"dup: entry 0x%X '%s'",
+			"dup: entry 0x%lX"  " '%s'",
 			(unsigned long int)dest_path_ptr, new->pe_path_component);
 		if (duplicate_until_this_component == source_path) break;
 		source_path = source_path->pe_next;
@@ -446,4 +446,3 @@ char *clean_and_log_fs_mapping_result(
 	}
 	return (cleaned_host_path);
 }
-

--- a/pathmapping/pathmapping_interf.c
+++ b/pathmapping/pathmapping_interf.c
@@ -150,7 +150,7 @@ char *custom_map_abstract_path(
 		rule_list_offs, &ctx, &abs_virtual_source_path_list,
 		&min_path_len, NULL/*call_translate_for_all_p*/,
 		SB2_INTERFACE_CLASS_EXEC);
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: rule_offs = %u", __func__, rule_offs);
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: rule_offs = %" PRI_SB_RTOO, __func__, rule_offs);
 
 	if (rule_offs) {
 		const char 	*errormsg = NULL;
@@ -300,7 +300,7 @@ end:
 	res->mres_readonly = 0;
 }
 
-/* this maps the path and then leaves "rule" and "exec_policy" to the stack, 
+/* this maps the path and then leaves "rule" and "exec_policy" to the stack,
  * because exec post-processing needs them
 */
 void sbox_map_path_for_exec(
@@ -355,4 +355,3 @@ void	force_path_to_mapping_result(mapping_results_t *res, const char *path)
 	res->mres_virtual_cwd = NULL;
 	res->mres_errno = 0;
 }
-

--- a/pathmapping/pathresolution.c
+++ b/pathmapping/pathresolution.c
@@ -32,7 +32,7 @@
  * - a _host path_ is a path that refers to the real filesystem
  *   (i.e. a mapped path)
  *
- * - a _real path_ is an absolute path where none of components is a 
+ * - a _real path_ is an absolute path where none of components is a
  *   symbolic link and it does not have any . or .. inside
  *   (see realpath(3) for details).
  *   NOTE that within Scratchbox 2 we may have both "host realpaths"
@@ -113,7 +113,7 @@ void remove_dots_from_path_list(struct path_entry_list *listp)
 	}
 	while (work) {
 		SB_LOG(SB_LOGLEVEL_NOISE2,
-			"remove_dots: work=0x%X examine '%s'",
+			"remove_dots: work=0x%lX examine '%s'",
 			(unsigned long int)work, work?work->pe_path_component:"");
 
 		if ((work->pe_path_component[0] == '.') &&
@@ -224,7 +224,7 @@ int clean_dotdots_from_path(
 
 	if ((work == NULL) || is_clean_path(abs_path) < 2) goto done;
 
-	/* step 2: 
+	/* step 2:
 	 * remove all ".." componets where the previous component
 	 * is already known to be a real directory (well, actually
 	 * known to be something else than a symlink)
@@ -265,7 +265,7 @@ int clean_dotdots_from_path(
 
 	if (path_has_nontrivial_dotdots == 0) goto done;
 
-	/* step 3: 
+	/* step 3:
 	 * remove all remaining ".." componets.
 	 * the previous component might be a symlink, so
 	 * path resolution must be done.
@@ -288,7 +288,7 @@ int clean_dotdots_from_path(
 			} else {
 				/* else parent is the root directory;
 				 * abs_path_to_parent is now empty,
-				 * get flags from the parent (this 
+				 * get flags from the parent (this
 				 * will get the "absolute" flag, among
 				 * other things) */
 				abs_path_to_parent.pl_flags = abs_path->pl_flags;
@@ -379,7 +379,7 @@ int clean_dotdots_from_path(
 
 				/* restart from the beginning of the new path: */
 				return(clean_dotdots_from_path(ctx, abs_path));
-			} 
+			}
 
 			SB_LOG(SB_LOGLEVEL_NOISE,
 				"clean_dotdots_from_path: <3>:same='%s'",
@@ -619,7 +619,7 @@ static ruletree_object_offset_t sb_path_resolution(
 		SB_LOG(SB_LOGLEVEL_NOISE, "path_resolution: test if symlink [%d] '%s'",
 			component_index, prefix_mapping_result_host_path);
 
-		if ((virtual_path_work_ptr->pe_flags & 
+		if ((virtual_path_work_ptr->pe_flags &
 		     (PATH_FLAGS_IS_SYMLINK | PATH_FLAGS_NOT_SYMLINK)) == 0) {
 			/* status unknow.
 			 * determine if "prefix_mapping_result_host_path" is a symbolic link.
@@ -806,8 +806,8 @@ static ruletree_object_offset_t sb_path_resolution_resolve_symlink(
 
 	if (virtual_path_work_ptr->pe_next) {
 		/* path has components after the symlink:
-		 * duplicate remaining path, it needs to 
-		 * be attached to symlink contents. 
+		 * duplicate remaining path, it needs to
+		 * be attached to symlink contents.
 		*/
 		rest_of_virtual_path = duplicate_path_entries_until(
 			NULL, virtual_path_work_ptr->pe_next);
@@ -823,7 +823,7 @@ static ruletree_object_offset_t sb_path_resolution_resolve_symlink(
 		/* absolute symlink.
 		 * This is easy: just join the symlink
 		 * and rest of path (+optional chroot prefix),
-		 * and further mapping operations will take 
+		 * and further mapping operations will take
 		 * care of the rest.
 		*/
 		struct path_entry *symlink_entries = NULL;
@@ -892,7 +892,7 @@ static ruletree_object_offset_t sb_path_resolution_resolve_symlink(
 				virtual_path_work_ptr->pe_prev,
 				virtual_source_path_list->pl_first);
 		} else {
-			/* else parent directory = rootdir, 
+			/* else parent directory = rootdir,
 			 * dirnam_entries=NULL signifies that. */
 			dirnam_entries = NULL;
 		}
@@ -979,7 +979,7 @@ static int get_and_check_host_cwd(
 		 * In this case the path can not be mapped.
 		 *
 		 * Added 2009-01-16: This actually happens sometimes;
-		 * there are configure scripts that find out MAX_PATH 
+		 * there are configure scripts that find out MAX_PATH
 		 * the hard way. So, if this process has already
 		 * logged this error, we'll suppress further messages.
 		 * [decided to add this check after I had seen 3686
@@ -997,7 +997,7 @@ static int get_and_check_host_cwd(
 	SB_LOG(SB_LOGLEVEL_DEBUG, "host cwd=%s", host_cwd);
 	return(0);
 }
-	
+
 /* ========== Mapping & path resolution, internal implementation: ========== */
 
 /* path_list is relative in the beginning;
@@ -1021,7 +1021,7 @@ static int relative_virtual_path_to_abs_path(
 	SB_LOG(SB_LOGLEVEL_DEBUG,
 		"relative_virtual_path_to_abs_path: converting to abs.path cwd=%s",
 		host_cwd);
-	
+
 	/* reversing of paths is expensive...try if a previous
 	 * result can be used, and call the reversing logic only if
 	 * CWD has been changed.
@@ -1072,7 +1072,7 @@ static int relative_virtual_path_to_abs_path(
 	path_list->pl_first = append_path_entries(
 		cwd_entries, path_list->pl_first);
 	path_list->pl_flags |= cwd_flags & ~PATH_FLAGS_HAS_TRAILING_SLASH;
-#if 0	
+#if 0
 	SB_LOG(SB_LOGLEVEL_DEBUG,
 		"relative_virtual_path_to_abs_path: abs.path is '%s'",
 		*abs_virtual_path_buffer_p);
@@ -1223,7 +1223,7 @@ char *sbox_virtual_path_to_abs_virtual_path(
 	return(result);
 }
 
-/* make sure to use disable_mapping(m); 
+/* make sure to use disable_mapping(m);
  * to prevent recursive calls to this function.
  * Returns results in *res.
  */
@@ -1392,7 +1392,7 @@ void sbox_map_path_internal__c_engine(
 			SB_LOG(SB_LOGLEVEL_ERROR,
 				"%s: conversion to absolute path failed "
 				"(can't map '%s')", __func__, mapping_result);
-			res->mres_error_text = 
+			res->mres_error_text =
 				"mapping failed; failed to make absolute path";
 			goto forget_mapping;
 		}
@@ -1427,7 +1427,7 @@ void sbox_map_path_internal__c_engine(
 				"%s: path resolution failed [%s]",
 				__func__, func_name);
 			mapping_result = NULL;
-			res->mres_error_text = 
+			res->mres_error_text =
 				"mapping failed; path resolution path failed";
 		} else {
 			int	flags;
@@ -1607,5 +1607,3 @@ char *sbox_reverse_path_internal__c_engine(
 
 	return (result_virtual_path);
 }
-
-

--- a/pathmapping/paths_ruletree_maint.c
+++ b/pathmapping/paths_ruletree_maint.c
@@ -67,7 +67,7 @@ ruletree_object_offset_t add_rule_to_ruletree(
 #endif
 
 	memset(&new_rule, 0, sizeof(new_rule));
-	
+
 	if (name) {
 		new_rule.rtree_fsr_name_offs = append_string_to_ruletree_file(name);
 	}
@@ -163,13 +163,12 @@ ruletree_object_offset_t add_rule_to_ruletree(
 
 	rule_location = append_struct_to_ruletree_file(&new_rule, sizeof(new_rule),
 		SB2_RULETREE_OBJECT_TYPE_FSRULE);
-	
+
 	SB_LOG(SB_LOGLEVEL_DEBUG,
-		"Added rule: %d (%s) / %d (%s), @ %u (link=%d)",
+		"Added rule: %d (%s) / %d (%s), @ %" PRI_SB_RTOO " (link=%d)",
 			selector_type, (selector ? selector : ""),
 			action_type, (action_str ? action_str : ""),
 			rule_location, rule_list_link);
 
 	return(rule_location);
 }
-

--- a/pathmapping/paths_ruletree_mapping.c
+++ b/pathmapping/paths_ruletree_mapping.c
@@ -109,7 +109,7 @@ static int ruletree_test_path_match(const char *full_path, size_t full_path_len,
 	}
 
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"ruletree_test_path_match '%s' (%zu), '%s' (%u) => %d (%s)",
+		"ruletree_test_path_match '%s' (%zu), '%s' (%" PRIu32 ") => %d (%s)",
 		full_path, full_path_len, selector, selector_len, result, match_type);
 	return(result);
 }

--- a/pathmapping/paths_ruletree_mapping.c
+++ b/pathmapping/paths_ruletree_mapping.c
@@ -55,10 +55,10 @@ static int ruletree_test_path_match(const char *full_path, size_t full_path_len,
 	uint32_t	selector_len;
 
 	if (!rp || !full_path) {
-		SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match fails"); 
+		SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match fails");
 		return(-1);
 	}
-	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match (%s), type=%d", 
+	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_test_path_match (%s), type=%d",
 		full_path, rp->rtree_fsr_selector_type);
 
 	selector = offset_to_ruletree_string_ptr(rp->rtree_fsr_selector_offs,
@@ -109,7 +109,7 @@ static int ruletree_test_path_match(const char *full_path, size_t full_path_len,
 	}
 
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"ruletree_test_path_match '%s' (%u), '%s' (%u) => %d (%s)",
+		"ruletree_test_path_match '%s' (%zu), '%s' (%u) => %d (%s)",
 		full_path, full_path_len, selector, selector_len, result, match_type);
 	return(result);
 }
@@ -231,7 +231,7 @@ ruletree_object_offset_t ruletree_get_rule_list_offs(
 
 	if (!fwd_rule_list_offs || !rev_rule_list_offs) {
 		const char *modename = sbox_session_mode;
-		
+
 		if (!modename)
 			modename = ruletree_catalog_get_string("MODES", "#default");
 		if (!modename) {
@@ -302,7 +302,7 @@ ruletree_object_offset_t ruletree_get_mapping_requirements(
 	free(abs_virtual_source_path_string);
 
 	STOP_AND_REPORT_PROCESSCLOCK(SB_LOGLEVEL_INFO, &clk1, "");
-	return (rule_offs); 
+	return (rule_offs);
 }
 
 /* returns an allocated buffer */
@@ -476,7 +476,7 @@ static char *execute_std_action(
 	case SB2_RULETREE_FSRULE_ACTION_MAP_TO:
 		cp = offset_to_ruletree_string_ptr(action->rtree_fsr_action_offs, NULL);
 		return(execute_map_to(abs_clean_virtual_path, "map_to", cp));
-		
+
 	case SB2_RULETREE_FSRULE_ACTION_REPLACE_BY:
 		cp = offset_to_ruletree_string_ptr(action->rtree_fsr_action_offs, NULL);
 		SB_LOG(SB_LOGLEVEL_DEBUG,
@@ -538,7 +538,7 @@ static char *execute_std_action(
 					str_offs = ruletree_objectlist_get_item(union_dir_list_offs, i);
 					src_paths[i] = offset_to_ruletree_string_ptr(str_offs, NULL);
 					SB_LOG(SB_LOGLEVEL_DEBUG,
-						"execute_std_action: union_dir src_path[%d]: %s", 
+						"execute_std_action: union_dir src_path[%d]: %s",
 						i, src_paths[i]);
 				}
 				union_dir_result = prep_union_dir(abs_clean_virtual_path,
@@ -594,7 +594,7 @@ static char *ruletree_execute_conditional_actions(
 		/* "rule_selector" is the rule which matched, and
 		 * brought us here (so it contains "dir","prefix"
 		 * or "path").
-		 * Each member in the "actions" array is a 
+		 * Each member in the "actions" array is a
                  * candidate for the rule which will be applied,
 		 * i.e. a suitable member from that array gives
 		 * instructions about what to do next */
@@ -608,7 +608,7 @@ static char *ruletree_execute_conditional_actions(
 
 				cond_str = offset_to_ruletree_string_ptr(action_cand_p->rtree_fsr_condition_offs, NULL);
 				SB_LOG(SB_LOGLEVEL_NOISE, "Condition test '%s'", cond_str);
-				
+
 				switch (action_cand_p->rtree_fsr_condition_type) {
 				case SB2_RULETREE_FSRULE_CONDITION_IF_ENV_VAR_IS_NOT_EMPTY:
 					if (!cond_str) continue;	/* continue if no env.var.name */
@@ -616,14 +616,14 @@ static char *ruletree_execute_conditional_actions(
 					if (!evp || !*evp) continue; /* continue if empty */
 					SB_LOG(SB_LOGLEVEL_NOISE, "Condition test: env.var was not empty");
 					break;	/* else test passed. */
-					
+
 				case SB2_RULETREE_FSRULE_CONDITION_IF_ENV_VAR_IS_EMPTY:
 					if (!cond_str) continue;	/* continue if no env.var.name */
 					evp = getenv(cond_str);
 					if (evp && *evp) continue; /* continue if not empty */
 					SB_LOG(SB_LOGLEVEL_NOISE, "Condition test: env.var was empty");
 					break;	/* else test passed. */
-				
+
 				case SB2_RULETREE_FSRULE_CONDITION_IF_ACTIVE_EXEC_POLICY_IS:
 					if (!cond_str ||
 					    !sbox_active_exec_policy_name ||
@@ -735,7 +735,7 @@ static char *ruletree_execute_conditional_actions(
 	 * Lua code) */
 	*errormsgp = "End of conditional action list";
 	return (NULL);
-			
+
     unimplemented_action_error:
 	SB_LOG(SB_LOGLEVEL_ERROR,
 		"Internal error: ruletree_execute_conditional_actions: Encountered "
@@ -809,7 +809,7 @@ char *ruletree_translate_path(
 			flagsp, exec_policy_name_ptr, errormsgp,
 			rule);
 		break;
-	
+
 	default:
 		SB_LOG(SB_LOGLEVEL_ERROR,
 			"ruletree_translate_path: Unknown action code %d",
@@ -844,4 +844,3 @@ char *ruletree_translate_path(
 	STOP_AND_REPORT_PROCESSCLOCK(SB_LOGLEVEL_INFO, &clk1, host_path);
 	return(host_path);
 }
-

--- a/preload/miscgates.c
+++ b/preload/miscgates.c
@@ -2,7 +2,7 @@
  * libsb2 -- misc. GATE fucntions of the scratchbox2 preload library
  *
  * Copyright (C) 2006,2007 Lauri Leukkunen <lle@rahina.org>
- * parts contributed by 
+ * parts contributed by
  * 	Riku Voipio <riku.voipio@movial.com>
  *	Toni Timonen <toni.timonen@movial.com>
  *	Lauri T. Aarnio
@@ -132,7 +132,7 @@ SB_LOG(SB_LOGLEVEL_DEBUG, "GETCWD: '%s'", sbox_path);
 			strncpy(buf, sbox_path, size);
 			free(sbox_path);
 		} else {
-			/* buf==NULL: real getcwd() used malloc() to 
+			/* buf==NULL: real getcwd() used malloc() to
 			 * allocate cwd (some implementations) [or the
 			 * behavior may be unspecified (posix definition)]
 			 * Assume memory was allocated, because the real
@@ -283,7 +283,7 @@ char *realpath_gate(
 				rp = resolved;
 				free(sbox_path);
 			} else {
-				/* resolved was null - assume that glibc 
+				/* resolved was null - assume that glibc
 				 * allocated memory */
 				free(rp);
 				rp = sbox_path;
@@ -294,7 +294,7 @@ char *realpath_gate(
 	return(rp);
 }
 
-/* gate for 
+/* gate for
  *     char *__realpath_chk (__const char *__restrict __name,
  *		char *__restrict __resolved, size_t __resolvedlen)
  * (__realpath_chk is yet another ugly trick from the creators of glibc)
@@ -310,7 +310,7 @@ char *__realpath_chk_gate(
 {
 	char *sbox_path = NULL;
 	char *rp;
-	
+
 	errno = *result_errno_ptr; /* restore to orig.value */
 	if ((rp = (*real__realpath_chk_ptr)(mapped_name->mres_result_path,
 		__resolved,__resolvedlen)) == NULL) {
@@ -328,7 +328,7 @@ char *__realpath_chk_gate(
 				rp = __resolved;
 				free(sbox_path);
 			} else {
-				/* resolved was null - assume that glibc 
+				/* resolved was null - assume that glibc
 				 * allocated memory */
 				free(rp);
 				rp = sbox_path;
@@ -454,7 +454,7 @@ int glob_gate(
 	if (test_if_address_is_in_glibc(realfnname, real_glob_ptr) == 0) {
 		/* glob() is not in glibc, use that directly.
 		 * Don't map the pattern; since glob() is somewhere else,
-		 * it is expected to use opendir(), stat(), etc from 
+		 * it is expected to use opendir(), stat(), etc from
 		 * glibc and those calls will be directed to us
 		 * => we'll do pathmapping later.
 		*/
@@ -466,12 +466,12 @@ int glob_gate(
 	/* else glob() is in glibc, and must be replaced completely
 	 * (uses a modified copy, copied from glibc) */
 
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: pattern='%s' gl_offs=%d, flags=0x%X",
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: pattern='%s' gl_offs=%zu, flags=0x%X",
 		realfnname, pattern, pglob->gl_offs, flags);
 	errno = *result_errno_ptr; /* restore to orig.value */
 	rc = do_glob(pattern, flags, errfunc, pglob);
 	*result_errno_ptr = errno;
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: returns %d (gl_pathc=%d)",
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: returns %d (gl_pathc=%zu)",
 		realfnname, rc, pglob->gl_pathc);
 	for (i=0; i < pglob->gl_pathc; i++) {
 		char *cp = pglob->gl_pathv[i + pglob->gl_offs];
@@ -479,7 +479,7 @@ int glob_gate(
 			realfnname, i, cp ? cp : "<NULL>");
 	}
 #endif
-	
+
 	return rc;
 }
 
@@ -510,7 +510,7 @@ int glob64_gate(
 	if (test_if_address_is_in_glibc(realfnname, real_glob64_ptr) == 0) {
 		/* glob64() is not in glibc, use that directly.
 		 * Don't map the pattern; since glob64() is somewhere else,
-		 * it is expected to use opendir(), stat(), etc from 
+		 * it is expected to use opendir(), stat(), etc from
 		 * glibc and those calls will be directed to us
 		 * => we'll do pathmapping later.
 		*/
@@ -522,12 +522,12 @@ int glob64_gate(
 	/* else glob64() needs to be replaced;
 	 * use a modified copy (copied from glibc) */
 
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: pattern='%s' gl_offs=%d, flags=0x%X",
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: pattern='%s' gl_offs=%zu, flags=0x%X",
 		realfnname, pattern, pglob->gl_offs, flags);
 	errno = *result_errno_ptr; /* restore to orig.value */
 	rc = do_glob64(pattern, flags, errfunc, pglob);
 	*result_errno_ptr = errno;
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: returns %d (gl_pathc=%d)",
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: returns %d (gl_pathc=%zu)",
 		realfnname, rc, pglob->gl_pathc);
 	for (i=0; i < pglob->gl_pathc; i++) {
 		char *cp = pglob->gl_pathv[i + pglob->gl_offs];
@@ -683,4 +683,3 @@ pid_t waitpid_gate(int *result_errno_ptr,
 	if(p > 1) log_wait_result(realfnname, p, *status);
 	return(p);
 }
-

--- a/preload/network.c
+++ b/preload/network.c
@@ -2,7 +2,7 @@
  * network.c -- Network API of the scratchbox2 preload library
  *
  * Copyright (C) 2006,2007 Lauri Leukkunen <lle@rahina.org>
- * parts contributed by 
+ * parts contributed by
  * 	Riku Voipio <riku.voipio@movial.com>
  *	Toni Timonen <toni.timonen@movial.com>
  * Copyright (C) 2010,2011 Nokia Corporation.
@@ -186,12 +186,12 @@ static int map_sockaddr_in(
 				output_addr->mapped_sockaddr_in.sin_port = htons(mapped_port);
 				output_addr->mapped_sockaddr_in.sin_addr = ina;
 				output_addr->mapped_sockaddr.sa_family = AF_INET;
-				
+
 				snprintf(output_addr->mapped_printable_dst_addr,
 					sizeof(output_addr->mapped_printable_dst_addr),
 					"AF_INET %s:%d", mapped_dst_addr, mapped_port);
 				return(0); /* ok to use this address */
-			case 0: 
+			case 0:
 				SB_LOG(SB_LOGLEVEL_ERROR,
 					"%s: IPv4 address mapping returned an "
 					"illegal string (inet_pton() can't convert it;"
@@ -287,12 +287,12 @@ static int map_sockaddr_in6(
 				output_addr->mapped_sockaddr_in6.sin6_port = htons(mapped_port);
 				output_addr->mapped_sockaddr_in6.sin6_addr = ina6;
 				output_addr->mapped_sockaddr.sa_family = AF_INET6;
-				
+
 				snprintf(output_addr->mapped_printable_dst_addr,
 					sizeof(output_addr->mapped_printable_dst_addr),
 					"AF_INET6 [%s]:%d", mapped_dst_addr, mapped_port);
 				return(0); /* ok to use this address */
-			case 0: 
+			case 0:
 				SB_LOG(SB_LOGLEVEL_ERROR,
 					"%s: IPv6 address mapping returned an "
 					"illegal string (inet_pton() can't convert it;"

--- a/preload/procfs.c
+++ b/preload/procfs.c
@@ -221,7 +221,7 @@ static char *select_exe_path_for_sb2(
 				"select_exe_path_for_sb2(%s, %s):"
 				" error while determining real path: %s",
 				orig_binary_name,
-				real_binary_name,
+			        real_binary_name ?: "null",
 				strerror(errno));
 			return(NULL);
 		}
@@ -298,8 +298,8 @@ static char *procfs_mapping_request_for_other_files(
                 const char *orig_binary_name;
                 const char *real_binary_name;
 
-                /* Check the process environment to find out is this 
-		 * runned under sb2 
+                /* Check the process environment to find out is this
+		 * runned under sb2
 		 */
                 (void)snprintf(pathbuf, sizeof(pathbuf), "%s/environ",
 			       pid_path);
@@ -321,7 +321,7 @@ static char *procfs_mapping_request_for_other_files(
 
                 exe_path_inside_sb2 = select_exe_path_for_sb2(
 			orig_binary_name, real_binary_name);
-		
+
                 /* this is not under runned binary */
                 if (!exe_path_inside_sb2) {
                         return(NULL);
@@ -345,7 +345,7 @@ static char *procfs_mapping_request_for_other_files(
 			return(strdup(pathbuf));
 		}
 		/* oops, failed to create the replacement.
-                 * must use the real link, it points to wrong place.. 
+                 * must use the real link, it points to wrong place..
 		 */
 		free((void*)exe_path_inside_sb2);
 		return(NULL);
@@ -391,4 +391,3 @@ char *procfs_mapping_request(const char *path)
 	SB_LOG(SB_LOGLEVEL_DEBUG, "procfs_mapping_request: not mapped");
 	return(NULL);
 }
-

--- a/rule_tree/rule_tree.c
+++ b/rule_tree/rule_tree.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -99,16 +100,16 @@ ruletree_object_offset_t append_struct_to_ruletree_file(void *ptr, size_t size, 
 
 	hdrp->rtree_obj_magic = SB2_RULETREE_MAGIC;
 	hdrp->rtree_obj_type = type;
-	
+
 	if (ruletree_ctx.rtree_ruletree_fd >= 0) {
-		location = lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END); 
+		location = lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END);
 		if (write(ruletree_ctx.rtree_ruletree_fd, ptr, size) < (int)size) {
 			SB_LOG(SB_LOGLEVEL_ERROR,
-				"Failed to append a struct (%d bytes) to the rule tree", size);
+				"Failed to append a struct (%zu bytes) to the rule tree", size);
 		}
-		if (ruletree_ctx.rtree_ruletree_hdr_p) 
+		if (ruletree_ctx.rtree_ruletree_hdr_p)
 			ruletree_ctx.rtree_ruletree_hdr_p->rtree_file_size =
-				lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END); 
+				lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END);
 	}
 	return(location);
 }
@@ -172,7 +173,7 @@ int create_ruletree_file(const char *ruletree_path,
 		return(-1);
 	}
 
-	if (lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END) != 0) { 
+	if (lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END) != 0) {
 		SB_LOG(SB_LOGLEVEL_DEBUG, "create_ruletree_file: file is not empty");
 		return(-1);
 	}
@@ -189,7 +190,7 @@ int create_ruletree_file(const char *ruletree_path,
 		SB2_RULETREE_OBJECT_TYPE_FILEHDR);
 
 	if (mmap_ruletree(&hdr) < 0) return(-1);
-	
+
 	return(0);
 }
 
@@ -308,7 +309,7 @@ const char *offset_to_ruletree_string_ptr(ruletree_object_offset_t offs,
 	if (strhdr) {
 		const char *str = (const char*)strhdr + sizeof(ruletree_string_hdr_t);
 		SB_LOG(SB_LOGLEVEL_NOISE2,
-			"offset_to_ruletree_string_ptr returns '%s' (%u)",
+			"offset_to_ruletree_string_ptr returns '%s' (%" PRIu32 ")",
 			str, strhdr->rtree_str_size);
 		if (lenp) {
 			*lenp = strhdr->rtree_str_size;
@@ -341,7 +342,7 @@ ruletree_object_offset_t append_string_to_ruletree_file(const char *str)
 	}
 	if (ruletree_ctx.rtree_ruletree_hdr_p)
 		ruletree_ctx.rtree_ruletree_hdr_p->rtree_file_size =
-			lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END); 
+			lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END);
 	return(location);
 }
 
@@ -370,13 +371,13 @@ ruletree_object_offset_t ruletree_objectlist_create_list(uint32_t size)
 	wr_result = write(ruletree_ctx.rtree_ruletree_fd, a, list_size_in_bytes);
 	if ((wr_result == -1) || ((size_t)wr_result < list_size_in_bytes)) {
 		SB_LOG(SB_LOGLEVEL_ERROR,
-			"Failed to append a list (%d items, %d bytes) to the rule tree", 
+			"Failed to append a list (%d items, %zu bytes) to the rule tree",
 			size, list_size_in_bytes);
 		location = 0; /* return error */
 	}
 	if (ruletree_ctx.rtree_ruletree_hdr_p)
 		ruletree_ctx.rtree_ruletree_hdr_p->rtree_file_size =
-			lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END); 
+			lseek(ruletree_ctx.rtree_ruletree_fd, 0, SEEK_END);
 	SB_LOG(SB_LOGLEVEL_DEBUG, "ruletree_objectlist_create_list: location=%d", location);
 	return(location);
 }
@@ -490,7 +491,7 @@ static ruletree_object_offset_t ruletree_find_bintree_entry(
 		SB_LOG(SB_LOGLEVEL_NOISE3,
 			"ruletree_find_bintree_entry: check @%d",
 			node_offs);
-		
+
 		if ((bintrp->rtree_bt_key1 == key1) &&
 		    (bintrp->rtree_bt_key2 == key2)) {
 			SB_LOG(SB_LOGLEVEL_NOISE3,
@@ -622,14 +623,14 @@ static ruletree_object_offset_t ruletree_create_inodestat(
 /* Inode number is the primary key to the bintree
  * (device number is the secondary key), but
  * sometimes inode allocation may be done somewhat
- * sequentially. For a slightly better balancing 
+ * sequentially. For a slightly better balancing
  * of the tree, reverse some bits of the key:
  * This algorithm takes the lowest 8 bits, reverses
  * them, and the result will be in bits 32..39 or
  * "k" below (rest of bits in "k" are copies of the
  * original bits or zero, those cause no harm here)
  *
- * For detailed explanation, see 
+ * For detailed explanation, see
  * http://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64Bits
 */
 static uint64_t ino_to_key(uint64_t ino)
@@ -644,7 +645,7 @@ static ruletree_object_offset_t	inodestats_bintree_root = 0;
 
 /* in: "handle" contains the keys
  * out: istat_struct has been filled, if a matching node was found.
- *	in any case, "handle" has been updated so that 
+ *	in any case, "handle" has been updated so that
  *      ruletree_set_inodestat() can be called later to add/update
  *	a istat_struct.
  * returns 0 if OK, negative if not found. */
@@ -656,7 +657,7 @@ int ruletree_find_inodestat(
 	ruletree_inodestat_t	*fsptr;
 
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"ruletree_find_inodestat (dev=%lld,ino=%lld,key=%llX)",
+		"ruletree_find_inodestat (dev=%lld,ino=%lld,key=%" PRIu64 ")",
 			(long long)handle->rfh_dev,
 			(long long)handle->rfh_ino,
 			ino_to_key(handle->rfh_ino));
@@ -675,7 +676,7 @@ int ruletree_find_inodestat(
 		inodestats_bintree_root, &handle->rfh_last_visited_node,
 		&handle->rfh_last_result);
 	if (!handle->rfh_offs) return(-1);
-		
+
 	bintrp = offset_to_ruletree_object_ptr(handle->rfh_offs,
 			SB2_RULETREE_OBJECT_TYPE_BINTREE);
 	if (!bintrp) return(-1);
@@ -689,7 +690,7 @@ int ruletree_find_inodestat(
 }
 
 /* set/add a inodestat structure to the binary tree.
- * ruletree_find_inodestat() must be called beforehand to 
+ * ruletree_find_inodestat() must be called beforehand to
  * fill "handle" (unless adding the very first node)
  *
  * returns 0 or offset to new binary tree root. */
@@ -698,7 +699,7 @@ ruletree_object_offset_t ruletree_set_inodestat(
 	inodesimu_t			*istat_struct)
 {
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"ruletree_set_inodestat (dev=%lld,ino=%lld,key=%llX))",
+		"ruletree_set_inodestat (dev=%lld,ino=%lld,key=%" PRIu64 "))",
 			(long long)handle->rfh_dev,
 			(long long)handle->rfh_ino,
 			ino_to_key(handle->rfh_ino));
@@ -919,7 +920,7 @@ static ruletree_object_offset_t ruletree_find_catalog_entry(
 
 		entry_name = offset_to_ruletree_string_ptr(ep->rtree_cat_name_offs,
 			&entry_name_len);
-		if (entry_name && 
+		if (entry_name &&
 		    (name_len == entry_name_len) &&
 		    !strcmp(name, entry_name)) {
 			/* found! */
@@ -975,7 +976,7 @@ static ruletree_catalog_entry_t *ruletree_catalog_add_or_find_object(
 				first_catalog_entry_offs, object_name, 0, &object_cat_entry);
 		}
 		return(object_cat_entry);
-	} 
+	}
 	/* else there is nothing in the catalog, add object */
 	if (parent_cat_entry) {
 		/* a subcatalog */
@@ -1270,4 +1271,3 @@ int ruletree_to_memory(void)
 	}
         return (attach_result);
 }
-

--- a/rule_tree/rule_tree.c
+++ b/rule_tree/rule_tree.c
@@ -76,16 +76,19 @@ void *offset_to_ruletree_object_ptr(ruletree_object_offset_t offs, uint32_t requ
 	ruletree_object_hdr_t	*hdrp = offset_to_raw_ruletree_ptr(offs);
 
 	if (!hdrp) {
-		SB_LOG(SB_LOGLEVEL_NOISE3, "%s: no hdrp @%u", __func__, offs);
+		SB_LOG(SB_LOGLEVEL_NOISE3, "%s: no hdrp @%" PRI_SB_RTOO,
+		       __func__, offs);
 		return(NULL);
 	}
 	if (hdrp->rtree_obj_magic != SB2_RULETREE_MAGIC) {
-		SB_LOG(SB_LOGLEVEL_NOISE3, "%s: wrong magic 0x%X @%u", __func__,
-			hdrp->rtree_obj_magic, offs);
+		SB_LOG(SB_LOGLEVEL_NOISE3,
+		       "%s: wrong magic 0x%X @%" PRI_SB_RTOO,
+		       __func__, hdrp->rtree_obj_magic, offs);
 		return(NULL);
 	}
 	if (required_type && (required_type != hdrp->rtree_obj_type)) {
-		SB_LOG(SB_LOGLEVEL_NOISE3, "%s: wrong type (req=0x%X, was 0x%X, @%u)",
+		SB_LOG(SB_LOGLEVEL_NOISE3,
+		       "%s: wrong type (req=0x%X, was 0x%X, @%" PRI_SB_RTOO ")",
 			__func__, required_type, hdrp->rtree_obj_type, offs);
 		return(NULL);
 	}
@@ -389,7 +392,9 @@ int ruletree_objectlist_set_item(
 	ruletree_objectlist_t		*listhdr;
 	ruletree_object_offset_t	*a;
 
-	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_objectlist_set_item(%d,%d,%d)", list_offs, n, value);
+	SB_LOG(SB_LOGLEVEL_NOISE, "ruletree_objectlist_set_item("
+	       "%" PRI_SB_RTOO ",%" PRIu32 ",%" PRI_SB_RTOO ")",
+	       list_offs, n, value);
 	if (!ruletree_ctx.rtree_ruletree_hdr_p) return (-1);
 	listhdr = offset_to_ruletree_object_ptr(list_offs,
 		SB2_RULETREE_OBJECT_TYPE_OBJECTLIST);
@@ -907,7 +912,7 @@ static ruletree_object_offset_t ruletree_find_catalog_entry(
 	}
 
 	SB_LOG(SB_LOGLEVEL_NOISE3,
-		"ruletree_find_catalog_entry from catalog @ %u)", catalog_offs);
+		"ruletree_find_catalog_entry from catalog @ %" PRI_SB_RTOO ")", catalog_offs);
 	entry_location = catalog_offs;
 	name_len = strlen(name);
 
@@ -925,7 +930,7 @@ static ruletree_object_offset_t ruletree_find_catalog_entry(
 		    !strcmp(name, entry_name)) {
 			/* found! */
 			SB_LOG(SB_LOGLEVEL_NOISE3,
-				"Found entry '%s' @ %u)", name, entry_location);
+				"Found entry '%s' @ %" PRI_SB_RTOO ")", name, entry_location);
 			*entry_ptr = ep;
 			return(entry_location);
 		}
@@ -1235,7 +1240,7 @@ ruletree_object_offset_t add_net_rule_to_ruletree(
 	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: ", __func__);
 	rule_location = append_struct_to_ruletree_file(rule, sizeof(*rule),
                 SB2_RULETREE_OBJECT_TYPE_NET_RULE);
-	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: done, @%u", __func__, rule_location);
+	SB_LOG(SB_LOGLEVEL_DEBUG, "%s: done, @%" PRI_SB_RTOO , __func__, rule_location);
         return(rule_location);
 }
 

--- a/rule_tree/rule_tree_rpc_client.c
+++ b/rule_tree/rule_tree_rpc_client.c
@@ -157,7 +157,7 @@ static int create_client_socket(void)
 	unlink_nomap_nolog(client_socket_path); /* remove old socket, if any. */
 
 	client_addr_len = sizeof(sa_family_t) + sock_path_len + 1;
-	
+
 	if (bind_nomap_nolog(client_socket, (struct sockaddr*)&client_address, client_addr_len) < 0) {
 		SB_LOG(SB_LOGLEVEL_ERROR,
 			"ruletree_rpc: Failed to bind client socket address (%s)",
@@ -248,7 +248,7 @@ static int send_command_receive_reply(
 	}
 
 	SB_LOG(SB_LOGLEVEL_DEBUG, "ruletree_rpc: sendto => %d", (int)sent_msg_size);
-		
+
 	received_msg_size = recvfrom_nomap_nolog(client_socket, reply, sizeof(*reply), 0,
 		(struct sockaddr*)NULL, (socklen_t*)NULL);
 	SB_LOG(SB_LOGLEVEL_DEBUG, "ruletree_rpc: recvfrom => %d", (int)received_msg_size);
@@ -263,7 +263,7 @@ static int send_command_receive_reply(
 		SB_LOG(SB_LOGLEVEL_NOISE, "unlocked client_socket_mutex");
 	}
 	SB_LOG(SB_LOGLEVEL_DEBUG,
-		"%s: Received reply type=%u", __func__, reply->hdr.rimr_message_type);
+		"%s: Received reply type=%" PRIu32, __func__, reply->hdr.rimr_message_type);
 	return(0);
 
     error_out:
@@ -348,9 +348,9 @@ void ruletree_rpc__vperm_set_ids(uint64_t dev, uint64_t ino,
 	ruletree_rpc_msg_command_t	command;
 	ruletree_rpc_msg_reply_t	reply;
 
-	if (set_uid) 
+	if (set_uid)
 		SB_LOG(SB_LOGLEVEL_DEBUG, "%s: uid=%d", __func__, uid);
-	if (set_gid) 
+	if (set_gid)
 		SB_LOG(SB_LOGLEVEL_DEBUG, "%s: gid=%d", __func__, gid);
 	memset(&command, 0, sizeof(command));
 	command.rimc_message_type = RULETREE_RPC_MESSAGE_COMMAND__SETFILEINFO;
@@ -395,7 +395,7 @@ void ruletree_rpc__vperm_set_mode(uint64_t dev, uint64_t ino,
 	command.rim_message.rimm_fileinfo.inodesimu_mode = virt_mode;
 	command.rim_message.rimm_fileinfo.inodesimu_suidsgid = suid_sgid_bits;
 
-	if ((real_mode & ~(S_ISUID | S_ISGID)) != 
+	if ((real_mode & ~(S_ISUID | S_ISGID)) !=
 	    (virt_mode & ~(S_ISUID | S_ISGID))) {
 		command.rim_message.rimm_fileinfo.inodesimu_active_fields |=
 			RULETREE_INODESTAT_SIM_MODE;
@@ -439,5 +439,3 @@ void ruletree_rpc__vperm_set_dev_node(uint64_t dev, uint64_t ino,
 	command.rim_message.rimm_fileinfo.inodesimu_rdev = rdev;
 	send_command_receive_reply(&command, &reply);
 }
-
-

--- a/sb2d/rule_tree_luaif.c
+++ b/sb2d/rule_tree_luaif.c
@@ -225,7 +225,8 @@ static int lua_sb_ruletree_catalog_get_uint32(lua_State *l)
 		if (uip) res = *uip;
 	}
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"lua_sb_ruletree_catalog_get_uint32 @%u => %u", offs, res);
+		"lua_sb_ruletree_catalog_get_uint32 @%" PRI_SB_RTOO " => %" PRIu32,
+	       offs, res);
 	lua_pushnumber(l, res);
 	return 1;
 }
@@ -246,7 +247,8 @@ static int lua_sb_ruletree_catalog_get_boolean(lua_State *l)
 		if (uip) res = *uip;
 	}
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"lua_sb_ruletree_catalog_get_boolean @%u => %u", offs, res);
+		"lua_sb_ruletree_catalog_get_boolean @%" PRI_SB_RTOO " => %" PRIu32,
+	       offs, res);
 	lua_pushboolean(l, res);
 	return 1;
 }
@@ -264,7 +266,8 @@ static int lua_sb_ruletree_catalog_get_string(lua_State *l)
 		str = ruletree_catalog_get_string(catalog_name, object_name);
 	}
 	SB_LOG(SB_LOGLEVEL_NOISE,
-		"lua_sb_ruletree_catalog_get_string @%u => %s", offs, str);
+		"lua_sb_ruletree_catalog_get_string @%" PRI_SB_RTOO " => %s",
+	       offs, str);
 	lua_pushstring(l, str);
 	return 1;
 }
@@ -281,7 +284,7 @@ static int lua_sb_ruletree_catalog_set(lua_State *l)
 		ruletree_object_offset_t	value_offset = lua_tointeger(l, 3);
 		status = ruletree_catalog_set(catalog_name, object_name, value_offset);
 		SB_LOG(SB_LOGLEVEL_NOISE,
-			"lua_sb_ruletree_catalog_set(%s,%s,%d) => %d",
+			"lua_sb_ruletree_catalog_set(%s,%s,%" PRI_SB_RTOO ") => %d",
 			catalog_name, object_name, value_offset, status);
 	} else {
 		SB_LOG(SB_LOGLEVEL_NOISE,
@@ -375,7 +378,8 @@ static int lua_sb_ruletree_new_uint32(lua_State *l)
 		uint32_t	ui = lua_tointeger(l, 1);
 		ui32_offs = append_uint32_to_ruletree_file(ui);
 		SB_LOG(SB_LOGLEVEL_NOISE,
-			"%s(%u) => %d", __func__, ui, ui32_offs);
+			"%s(%" PRIu32 ") => %" PRI_SB_RTOO,
+		       __func__, ui, ui32_offs);
 	} else {
 		SB_LOG(SB_LOGLEVEL_NOISE,
 			"%s => %d", __func__, ui32_offs);
@@ -393,10 +397,11 @@ static int lua_sb_ruletree_new_boolean(lua_State *l)
 		uint32_t	ui = lua_toboolean(l, 1);
 		ui32_offs = append_boolean_to_ruletree_file(ui);
 		SB_LOG(SB_LOGLEVEL_NOISE,
-			"%s(%u) => %d", __func__, ui, ui32_offs);
+			"%s(%" PRIu32 ") => %" PRI_SB_RTOO, __func__, ui,
+		       ui32_offs);
 	} else {
-		SB_LOG(SB_LOGLEVEL_NOISE,
-			"%s => %d", __func__, ui32_offs);
+		SB_LOG(SB_LOGLEVEL_NOISE, "%s => %" PRI_SB_RTOO,
+		       __func__, ui32_offs);
 	}
 	lua_pushnumber(l, ui32_offs);
 	return 1;
@@ -429,9 +434,9 @@ static int lua_sb_add_net_rule_to_ruletree(lua_State *l)
 	int	n = lua_gettop(l);
 	uint32_t rule_location = 0;
 
-	/* params: 
+	/* params:
 	 *  1. ruletype (int),
-	 *  2. func_name (offset of a string) 
+	 *  2. func_name (offset of a string)
 	 *  3. binary_name (offset of a string)
 	 *  4. address (offset of a string)
 	 *  5. port (int)
@@ -445,7 +450,7 @@ static int lua_sb_add_net_rule_to_ruletree(lua_State *l)
 	if (n == 11) {
 		ruletree_net_rule_t	rule;
 		const char *errno_str;
-		
+
 		SB_LOG(SB_LOGLEVEL_NOISE, "%s:", __func__);
 
 		rule.rtree_net_ruletype = lua_tointeger(l, 1);
@@ -546,4 +551,3 @@ int lua_bind_ruletree_functions(lua_State *l)
 
 	return 0;
 }
-

--- a/sb2d/server_socket.c
+++ b/sb2d/server_socket.c
@@ -133,7 +133,7 @@ int receive_command_from_server_socket(struct sockaddr_un *client_address,
 	if (FD_ISSET(server_socket, &in_set)) {
 		received_msg_size = recvfrom(server_socket, command, sizeof(*command), 0,
 			(struct sockaddr*)client_address, &addrlen);
-		SB_LOG(SB_LOGLEVEL_DEBUG, "recvfrom => %d (%s)", 
+		SB_LOG(SB_LOGLEVEL_DEBUG, "recvfrom => %d (%s)",
 			(int)received_msg_size, client_address->sun_path);
 		if (received_msg_size <= 0) {
 			perror(progname);
@@ -167,7 +167,7 @@ int receive_command_from_server_socket(struct sockaddr_un *client_address,
 						__func__, ie->name);
 					if (!strcmp(ie->name, "ssock")) {
 						SB_LOG(SB_LOGLEVEL_DEBUG,
-							"%s: server socket has been deleted.",
+							"%s: server socket %s has been deleted.",
 							__func__, ie->name);
 						return(SOCKET_DELETED);
 					}
@@ -182,4 +182,3 @@ int receive_command_from_server_socket(struct sockaddr_un *client_address,
 	}
 	return(RECEIVE_FAILED_TRY_AGAIN);
 }
-

--- a/sblib/sb_log.c
+++ b/sblib/sb_log.c
@@ -13,13 +13,13 @@
  *     - The log message. If the original message contains tabs and/or
  *       newlines, those will be filtered out.
  *     - Optionally, source file name and line number.
- * 2) Simple format minimizes varying information and makes it easier to 
+ * 2) Simple format minimizes varying information and makes it easier to
  *    compare log files from different runs. Fields are:
  *     - Log level
  *     - Process name
  *     - The message
  *     - Optionally, source file name and line number.
- *    Simple format can be enabled by setting environment variable 
+ *    Simple format can be enabled by setting environment variable
  *    "SBOX_MAPPING_LOGFORMAT" to "simple".
  *
  * Note that logfiles are used by at least two other components
@@ -208,7 +208,7 @@ void sblog_init_level_logfile_format(const char *opt_level, const char *opt_logf
 		    sbox_orig_binary_name &&
 		    strcmp(sbox_exec_name, sbox_orig_binary_name)) {
 			/* this is an interpreter, running a script.
-			 * set .sbl_binary_name to 
+			 * set .sbl_binary_name to
 			 * scriptbasename{interpreterbasename}
 			*/
 			char *cp;
@@ -265,7 +265,7 @@ void sblog_init_level_logfile_format(const char *opt_level, const char *opt_logf
 			" [] "
 			"ppid=%d <%s> (%s) ----------%s",
 			getppid(),
-			sbox_exec_name ? 
+			sbox_exec_name ?
 				sbox_exec_name : "",
 			sbox_active_exec_policy_name ?
 				sbox_active_exec_policy_name : "",
@@ -293,8 +293,8 @@ void sblog_vprintf_line_to_logfile(
 	va_list		ap)
 {
 	char	tstamp[LOG_TIMESTAMP_BUFSIZE];
-	char	logmsg[LOG_MSG_MAXLEN];
-	char	finalmsg[LOG_LINE_BUFSIZE];
+        char	logmsg[LOG_MSG_MAXLEN] = {'\0'};
+        char	finalmsg[LOG_LINE_BUFSIZE];
 	int	msglen;
 	char	*forbidden_chrp;
 	char	optional_src_location[LOG_SRCLOCATION_MAXLEN];
@@ -364,18 +364,18 @@ void sblog_vprintf_line_to_logfile(
 	case SB_LOGLEVEL_NOTICE:	levelname = "NOTICE"; break;
 	/* default is to pass level info as numbers */
 	}
-	
+
 	if (sb_log_state.sbl_simple_format) {
 		/* simple format. No timestamp or pid, this makes
 		 * it easier to compare logfiles.
 		*/
 		if(levelname) {
 			snprintf(finalmsg, sizeof(finalmsg), "(%s)\t%s\t%s%s\n",
-				levelname, sb_log_state.sbl_binary_name, 
+				levelname, sb_log_state.sbl_binary_name,
 				logmsg, optional_src_location);
 		} else {
 			snprintf(finalmsg, sizeof(finalmsg), "(%d)\t%s\t%s%s\n",
-				level, sb_log_state.sbl_binary_name, 
+				level, sb_log_state.sbl_binary_name,
 				logmsg, optional_src_location);
 		}
 	} else {
@@ -394,12 +394,12 @@ void sblog_vprintf_line_to_logfile(
 		/* full format */
 		if(levelname) {
 			snprintf(finalmsg, sizeof(finalmsg), "%s (%s)\t%s%s\t%s%s\n",
-				tstamp, levelname, sb_log_state.sbl_binary_name, 
+				tstamp, levelname, sb_log_state.sbl_binary_name,
 				process_and_thread_id, logmsg,
 				optional_src_location);
 		} else {
 			snprintf(finalmsg, sizeof(finalmsg), "%s (%d)\t%s%s\t%s%s\n",
-				tstamp, level, sb_log_state.sbl_binary_name, 
+				tstamp, level, sb_log_state.sbl_binary_name,
 				process_and_thread_id, logmsg,
 				optional_src_location);
 		}

--- a/utils/sb2-ruletree.c
+++ b/utils/sb2-ruletree.c
@@ -62,7 +62,7 @@ int open_nomap_nolog(const char *pathname, int flags, ...)
 	return open(pathname, flags, mode);
 }
 
-char *sbox_session_dir = NULL; /* Fake var, referenced by the library=>must have something*/ 
+char *sbox_session_dir = NULL; /* Fake var, referenced by the library=>must have something*/
 
 /* -------------------- */
 
@@ -87,7 +87,7 @@ static void dump_rules(ruletree_object_offset_t offs, int indent)
 	if (print_ruletree_offsets) {
 		if (rule_dumped[offs]) {
 			print_indent(indent + 1);
-			printf("[ => @ %u]\n", offs);
+			printf("[ => @ %" PRI_SB_RTOO "]\n", offs);
 			return;
 		}
 	}
@@ -95,7 +95,7 @@ static void dump_rules(ruletree_object_offset_t offs, int indent)
 
 	print_indent(indent);
 	if (print_ruletree_offsets) {
-		printf("{ Rule[%u]:\n", (unsigned)offs);
+		 printf("{ Rule[%u]:\n", (unsigned)offs);
 	} else {
 		printf("{ Rule:\n");
 	}
@@ -201,7 +201,7 @@ static void dump_rules(ruletree_object_offset_t offs, int indent)
 		       printf("dlopen ");
 		printf(")\n");
 	}
-	
+
 	if (rule->rtree_fsr_binary_name) {
 		const char *bin_name = offset_to_ruletree_string_ptr(rule->rtree_fsr_binary_name, NULL);
 		print_indent(indent+1);
@@ -219,26 +219,26 @@ static void dump_rules(ruletree_object_offset_t offs, int indent)
 	switch (rule->rtree_fsr_action_type) {
 	case SB2_RULETREE_FSRULE_ACTION_FALLBACK_TO_OLD_MAPPING_ENGINE:
 		printf("FALLBACK_TO_OLD_MAPPING_ENGINE\n");
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_PROCFS:
 		printf("sb2_procfs_mapper\n");
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_UNION_DIR:
 #if 0
 		printf("union_dir => rule->rtree_fsr_rule_list_link\n");
 #endif
 		printf("\n");
 		rule_list_link_label = "union_dir";
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_USE_ORIG_PATH:
 		printf("use_orig_path\n");
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_FORCE_ORIG_PATH:
 		printf("force_orig_path\n");
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_FORCE_ORIG_PATH_UNLESS_CHROOT:
 		printf("force_orig_path_unless_chroot\n");
-		break;	
+		break;
 	case SB2_RULETREE_FSRULE_ACTION_REPLACE_BY:
 		printf("replace_by '%s'\n",
 			offset_to_ruletree_string_ptr(rule->rtree_fsr_action_offs, NULL));
@@ -298,7 +298,7 @@ static void dump_rules(ruletree_object_offset_t offs, int indent)
 
 	if (rule->rtree_fsr_rule_list_link) {
 		print_indent(indent+1);
-		printf("%s (%u) = {\n", rule_list_link_label, rule->rtree_fsr_rule_list_link);
+		printf("%s (%" PRI_SB_RTOO ") = {\n", rule_list_link_label, rule->rtree_fsr_rule_list_link);
 		dump_objectlist(rule->rtree_fsr_rule_list_link, indent + 2);
 		print_indent(indent+1);
 		printf("}\n");
@@ -315,7 +315,7 @@ static void dump_exec_selection_rules(ruletree_object_offset_t offs, int indent)
 	if (print_ruletree_offsets) {
 		if (rule_dumped[offs]) {
 			print_indent(indent + 1);
-			printf("[ => @ %u]\n", offs);
+			printf("[ => @ %" PRI_SB_RTOO "]\n", offs);
 			return;
 		}
 	}
@@ -352,7 +352,7 @@ static void dump_exec_pp_rules(ruletree_object_offset_t offs, int indent)
 	if (print_ruletree_offsets) {
 		if (rule_dumped[offs]) {
 			print_indent(indent + 1);
-			printf("[ => @ %u]\n", offs);
+			printf("[ => @ %" PRI_SB_RTOO "]\n", offs);
 			return;
 		}
 	}
@@ -407,7 +407,7 @@ static void dump_net_rules(ruletree_object_offset_t offs, int indent)
 	if (print_ruletree_offsets) {
 		if (rule_dumped[offs]) {
 			print_indent(indent + 1);
-			printf("[ => @ %u]\n", offs);
+			printf("[ => @ %" PRI_SB_RTOO "]\n", offs);
 			return;
 		}
 	}
@@ -493,7 +493,7 @@ static void dump_objectlist(ruletree_object_offset_t list_offs, int indent)
 	if (print_ruletree_offsets) {
 		printf("{ list[%u], size=%u:\n", (unsigned)list_offs, list_size);
 	} else {
-		printf("{ list, size=%u:\n", list_size);
+		printf("{ list, size=%" PRIu32 ":\n", list_size);
 	}
 
 	for (i = 0; i < list_size; i++) {
@@ -571,7 +571,9 @@ static void dump_bintree(ruletree_object_offset_t tree_offs, int indent,
 		if (print_ruletree_offsets) {
 			printf("[%u]", (unsigned)tree_offs);
 		}
-		printf(", key=(%llu,%llu) less=%u, more=%u, value @%u\n",
+		printf(", key=(%llu,%llu) less=%" PRI_SB_RTOO
+		       ", more=%" PRI_SB_RTOO
+		       ", value @%" PRI_SB_RTOO "\n",
 			(long long unsigned int)bthdr->rtree_bt_key1,
 			(long long unsigned int)bthdr->rtree_bt_key2,
 			bthdr->rtree_bt_link_less, bthdr->rtree_bt_link_more,
@@ -613,7 +615,7 @@ static void print_ruletree_object_type(ruletree_object_offset_t obj_offs)
 		uint32_t *uip;
 
 		if (print_ruletree_offsets) {
-			printf("@%u: ", obj_offs);
+			printf("@%" PRI_SB_RTOO ": ", obj_offs);
 		}
 		switch (hdr->rtree_obj_type) {
 		case SB2_RULETREE_OBJECT_TYPE_FILEHDR:
@@ -648,19 +650,19 @@ static void print_ruletree_object_type(ruletree_object_offset_t obj_offs)
 					printf("INODESTAT: dev=%lld ino=%lld act=0x%X",
 						(long long)fsp->rtree_inode_simu.inodesimu_dev,
 						(long long)fsp->rtree_inode_simu.inodesimu_ino, a);
-					if (a & RULETREE_INODESTAT_SIM_UID) 
+					if (a & RULETREE_INODESTAT_SIM_UID)
 						printf(" uid=%d",
 							(int)fsp->rtree_inode_simu.inodesimu_uid);
-					if (a & RULETREE_INODESTAT_SIM_GID) 
+					if (a & RULETREE_INODESTAT_SIM_GID)
 						printf(" gid=%d",
 							(int)fsp->rtree_inode_simu.inodesimu_gid);
-					if (a & RULETREE_INODESTAT_SIM_MODE) 
+					if (a & RULETREE_INODESTAT_SIM_MODE)
 						printf(" mode=0%o",
 							(int)fsp->rtree_inode_simu.inodesimu_mode);
-					if (a & RULETREE_INODESTAT_SIM_SUIDSGID) 
+					if (a & RULETREE_INODESTAT_SIM_SUIDSGID)
 						printf(" suid_sgid=0%o",
 							(int)fsp->rtree_inode_simu.inodesimu_suidsgid);
-					if (a & RULETREE_INODESTAT_SIM_DEVNODE) 
+					if (a & RULETREE_INODESTAT_SIM_DEVNODE)
 						printf(" device_type=0%o rdev=0x%llX",
 							(int)fsp->rtree_inode_simu.inodesimu_devmode,
 							(long long)fsp->rtree_inode_simu.inodesimu_rdev);
@@ -672,7 +674,7 @@ static void print_ruletree_object_type(ruletree_object_offset_t obj_offs)
 		case SB2_RULETREE_OBJECT_TYPE_UINT32:
 			uip = ruletree_get_pointer_to_uint32(obj_offs);
 			if (uip)
-				printf("UINT32 %u (0x%X)", *uip, *uip);
+				printf("UINT32 %" PRIu32 " (0x%X)", *uip, *uip);
 			else
 				printf("UINT32 <none; got NULL pointer>");
 			break;
@@ -735,7 +737,7 @@ static void dump_catalog(ruletree_object_offset_t catalog_offs, const char *cata
 	if (print_ruletree_offsets) {
 		if (rule_dumped[catalog_offs]) {
 			print_indent(indent);
-			printf("[ => Catalog @ %u '%s']\n", catalog_offs, catalog_name);
+			printf("[ => Catalog @ %" PRI_SB_RTOO " '%s']\n", catalog_offs, catalog_name);
 			return;
 		}
 	}
@@ -743,14 +745,14 @@ static void dump_catalog(ruletree_object_offset_t catalog_offs, const char *cata
 
 	print_indent(indent);
 	if (print_ruletree_offsets) {
-		printf("Catalog @ %u '%s':\n", catalog_offs, catalog_name);
+		printf("Catalog @ %" PRI_SB_RTOO " '%s':\n", catalog_offs, catalog_name);
 	} else {
 		printf("Catalog '%s':\n", catalog_name);
 	}
 
 	catalog = offset_to_ruletree_object_ptr(catalog_offs,
 		SB2_RULETREE_OBJECT_TYPE_CATALOG);
-	
+
 	if (!catalog) {
 		print_indent(indent+1);
 		printf("[empty]\n");
@@ -805,7 +807,7 @@ static void dump_catalog(ruletree_object_offset_t catalog_offs, const char *cata
 	}
 	print_indent(indent);
 	if (print_ruletree_offsets) {
-		printf("End of Catalog @ %u '%s'.\n", catalog_offs, catalog_name);
+		printf("End of Catalog @ %" PRI_SB_RTOO " '%s'.\n", catalog_offs, catalog_name);
 	} else {
 		printf("End of Catalog '%s'.\n", catalog_name);
 	}
@@ -857,4 +859,3 @@ int main(int argc, char *argv[])
 	}
 	return(0);
 }
-


### PR DESCRIPTION
- Fix potential SEGV in `sblog_init_level_logfile_format`.
- Make use of inttypes PRI macro to use the correct format specifier
  depending on the build target architecture.
- Add attribute to sb_log so mistakes in format strings
  can be detect at compile time rather then at runtime.

Contains #23 and #32